### PR TITLE
Fix footprint appearing before AOS time

### DIFF
--- a/OscarWatch.Core/Models/SatelliteTrackState.cs
+++ b/OscarWatch.Core/Models/SatelliteTrackState.cs
@@ -10,7 +10,7 @@ public sealed class SatelliteTrackState
     public double? AheadAzimuthDeg { get; init; }
     public IReadOnlyList<GeoCoordinate> GroundTrack { get; init; } = [];
     public IReadOnlyList<GeoCoordinate> Footprint { get; init; } = [];
-    /// <summary>Angular radius of the 0°-elevation footprint on Earth (degrees).</summary>
+    /// <summary>Angular radius of the minimum-elevation footprint on Earth (degrees).</summary>
     public double FootprintRadiusDeg { get; init; }
     /// <summary>True when the spacecraft is in full sunlight; false when in Earth's shadow.</summary>
     public bool IsSunlit { get; init; } = true;

--- a/OscarWatch.Core/Services/SatelliteVisualCache.cs
+++ b/OscarWatch.Core/Services/SatelliteVisualCache.cs
@@ -34,10 +34,17 @@ internal sealed class SatelliteVisualCache
         return track.Count >= 2;
     }
 
-    public bool TryGetFreshFootprint(string noradId, DateTime utc, out IReadOnlyList<GeoCoordinate> footprint)
+    public bool TryGetFreshFootprint(
+        string noradId,
+        DateTime utc,
+        double minimumElevationDeg,
+        out IReadOnlyList<GeoCoordinate> footprint)
     {
         footprint = [];
         if (!_entries.TryGetValue(noradId, out var entry))
+            return false;
+
+        if (Math.Abs(entry.FootprintMinElevationDeg - minimumElevationDeg) > 0.001)
             return false;
 
         if (utc - entry.FootprintUtc > FootprintRefreshInterval)
@@ -53,6 +60,7 @@ internal sealed class SatelliteVisualCache
         public DateTime GroundTrackUtc;
         public IReadOnlyList<GeoCoordinate> Footprint { get; set; } = [];
         public DateTime FootprintUtc;
+        public double FootprintMinElevationDeg;
         public double FootprintRadiusDeg;
     }
 }

--- a/OscarWatch.Core/Services/TrackingOrchestrator.cs
+++ b/OscarWatch.Core/Services/TrackingOrchestrator.cs
@@ -40,6 +40,7 @@ public sealed class TrackingOrchestrator
     public IReadOnlyList<SatelliteTrackState> GetLiveStates(DateTime utc)
     {
         var site = _settings.Current.GroundStation;
+        var minimumElevationDeg = _settings.Current.MinimumElevationDeg;
         var sats = _tleService.GetEnabledSatellites(_settings.Current);
         var states = new List<SatelliteTrackState>();
         var sunEci = SunPositionCalculator.GetPosition(utc);
@@ -75,15 +76,18 @@ public sealed class TrackingOrchestrator
                     cache.GroundTrackUtc = utc;
                 }
 
-                if (!_visualCache.TryGetFreshFootprint(sat.NoradId, utc, out var footprint))
+                if (!_visualCache.TryGetFreshFootprint(sat.NoradId, utc, minimumElevationDeg, out var footprint))
                 {
-                    footprint = _groundGeometry.GetFootprint(sat, utc, minimumElevationDeg: 0);
+                    footprint = _groundGeometry.GetFootprint(sat, utc, minimumElevationDeg);
                     cache.Footprint = footprint;
                     cache.FootprintUtc = utc;
+                    cache.FootprintMinElevationDeg = minimumElevationDeg;
+                    cache.FootprintRadiusDeg = FootprintGeometry.HorizonRadiusDeg(altKm, minimumElevationDeg);
                 }
-
-                if (cache.FootprintRadiusDeg <= 0)
-                    cache.FootprintRadiusDeg = FootprintGeometry.HorizonRadiusDeg(altKm, minimumElevationDeg: 0);
+                else if (cache.FootprintRadiusDeg <= 0)
+                {
+                    cache.FootprintRadiusDeg = FootprintGeometry.HorizonRadiusDeg(altKm, minimumElevationDeg);
+                }
 
                 var footprintRadiusDeg = cache.FootprintRadiusDeg > 0
                     ? cache.FootprintRadiusDeg

--- a/OscarWatch.Tests/FootprintGeometryTests.cs
+++ b/OscarWatch.Tests/FootprintGeometryTests.cs
@@ -1,0 +1,31 @@
+using OscarWatch.Core.Geo;
+
+namespace OscarWatch.Tests;
+
+public sealed class FootprintGeometryTests
+{
+    [Theory]
+    [InlineData(400, 0, 19.0, 20.0)]
+    [InlineData(400, 5, 13.5, 15.5)]
+    [InlineData(400, 10, 8.0, 11.0)]
+    public void HorizonRadiusDeg_shrinks_as_minimum_elevation_increases(
+        double altitudeKm,
+        double minimumElevationDeg,
+        double minExpectedDeg,
+        double maxExpectedDeg)
+    {
+        var radius = FootprintGeometry.HorizonRadiusDeg(altitudeKm, minimumElevationDeg);
+        Assert.InRange(radius, minExpectedDeg, maxExpectedDeg);
+    }
+
+    [Fact]
+    public void HorizonRadiusDeg_at_zero_is_larger_than_at_pass_minimum_elevation()
+    {
+        const double altitudeKm = 400;
+        var atHorizon = FootprintGeometry.HorizonRadiusDeg(altitudeKm, minimumElevationDeg: 0);
+        var atFive = FootprintGeometry.HorizonRadiusDeg(altitudeKm, minimumElevationDeg: 5);
+
+        Assert.True(atHorizon > atFive);
+        Assert.InRange(atHorizon - atFive, 4.5, 5.5);
+    }
+}

--- a/help/map-and-sidebar.html
+++ b/help/map-and-sidebar.html
@@ -35,7 +35,8 @@
       <h2>World map</h2>
       <p>
         The map shows the satellite <strong>sub-satellite point</strong> (where it is over the Earth),
-        its <strong>ground track</strong>, and a <strong>footprint</strong> (rough visibility circle).
+        its <strong>ground track</strong>, and a <strong>footprint</strong> (the area on Earth where the
+        satellite is at or above your minimum elevation from Settings → Tracking).
         Your station is marked on the map.
       </p>
       <ul>

--- a/help/settings.html
+++ b/help/settings.html
@@ -39,7 +39,8 @@
 
       <h2>Tracking</h2>
       <ul>
-        <li><strong>Minimum elevation</strong> — passes below this angle are hidden from predictions.</li>
+        <li><strong>Minimum elevation</strong> — passes below this angle are hidden from predictions, and the
+          world-map footprint uses the same threshold so it reaches your station when AOS begins.</li>
         <li><strong>Prediction hours</strong> — how far ahead to compute passes.</li>
         <li><strong>TLE updates</strong> — when to fetch fresh orbital data automatically. You can also use <strong>Satellites → Refresh TLEs</strong> anytime.</li>
         <li><strong>Check for transponder database updates on startup</strong> — downloads <a href="https://tle.oscarwatch.org/satellite_database.json">tle.oscarwatch.org/satellite_database.json</a> when the app opens and offers to merge new satellites/modes (on by default). Use <strong>Satellites → Update transponder database…</strong> to check manually.</li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users reported that the world-map footprint reaches their station before the pass list AOS time, and that timing disagrees with GoSatWatch.

## Root cause

Pass prediction uses **Settings → Tracking → Minimum elevation** (default 5°) for AOS/LOS, but the live map footprint was always computed at **0°** elevation. The 0° circle is ~5° larger in radius for typical LEO passes, so the footprint can cover your QTH several minutes before AOS.

## Fix

- Draw the live footprint at the same `MinimumElevationDeg` used for pass prediction.
- Invalidate cached footprint rings when the minimum elevation setting changes.
- Update help text to describe the linked behaviour.
- Add unit tests for footprint radius vs minimum elevation.

## Testing

- `dotnet test OscarWatch.Tests/OscarWatch.Tests.csproj` — 259 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a310990-9c86-4330-9402-cb4899c57bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a310990-9c86-4330-9402-cb4899c57bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

