### PR TITLE
Add the night side of the planet to the map

### DIFF
--- a/OscarWatch.Core/Models/AppSettings.cs
+++ b/OscarWatch.Core/Models/AppSettings.cs
@@ -19,6 +19,7 @@ public sealed class AppSettings
     public AppThemePreference Theme { get; set; } = AppThemePreference.System;
     /// <summary>Show ground-track direction arrows inside satellite footprints on the world map.</summary>
     public bool ShowFootprintMotionArrows { get; set; } = true;
+    public bool ShowGrayline { get; set; } = true;
     public VoiceAnnouncementSettings VoiceAnnouncements { get; set; } = new();
     public Dictionary<string, SatelliteFrequencySelection> FrequencySelections { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public double FrequencyOverlayX { get; set; } = 12;

--- a/OscarWatch.Core/Orbit/GraylineCalculator.cs
+++ b/OscarWatch.Core/Orbit/GraylineCalculator.cs
@@ -1,0 +1,132 @@
+namespace OscarWatch.Core.Orbit;
+
+public static class GraylineCalculator
+{
+    private const double EarthRadiusDeg = 90.0;
+
+    public static (double LatitudeDeg, double LongitudeDeg) GetSubsolarPoint(DateTime utc)
+    {
+        var sun = SunPositionCalculator.GetPosition(utc);
+
+        var distKm = Math.Sqrt(sun.XKm * sun.XKm + sun.YKm * sun.YKm + sun.ZKm * sun.ZKm);
+        if (distKm <= 0)
+            return (0, 0);
+
+        var declinationRad = Math.Asin(sun.ZKm / distKm);
+        var latDeg = declinationRad * 180.0 / Math.PI;
+
+        var raRad = Math.Atan2(sun.YKm, sun.XKm);
+
+        var gmstRad = GetGmstRad(utc);
+
+        var lonRad = raRad - gmstRad;
+        var lonDeg = lonRad * 180.0 / Math.PI;
+        lonDeg = ((lonDeg + 180.0) % 360.0 + 360.0) % 360.0 - 180.0;
+
+        return (latDeg, lonDeg);
+    }
+
+    public static List<(double LatDeg, double LonDeg)> GetTerminatorRing(
+        DateTime utc,
+        int steps = 360)
+    {
+        var (subLat, subLon) = GetSubsolarPoint(utc);
+        return GetTerminatorRingFromSubsolar(subLat, subLon, steps);
+    }
+
+    public static List<(double LatDeg, double LonDeg)> GetTerminatorRingFromSubsolar(
+        double subLatDeg,
+        double subLonDeg,
+        int steps = 360)
+    {
+        var points = new List<(double, double)>(steps + 1);
+
+        var subLatRad = subLatDeg * Math.PI / 180.0;
+        var subLonRad = subLonDeg * Math.PI / 180.0;
+        var termAngleRad = Math.PI / 2.0;
+
+        for (var i = 0; i <= steps; i++)
+        {
+            var azRad = 2.0 * Math.PI * i / steps;
+
+            var sinLat = Math.Sin(subLatRad) * Math.Cos(termAngleRad)
+                       + Math.Cos(subLatRad) * Math.Sin(termAngleRad) * Math.Cos(azRad);
+            sinLat = Math.Clamp(sinLat, -1.0, 1.0);
+            var latRad = Math.Asin(sinLat);
+
+            var cosLat = Math.Cos(latRad);
+            double lonRad;
+            if (Math.Abs(cosLat) < 1e-10)
+            {
+                lonRad = subLonRad;
+            }
+            else
+            {
+                var sinDLon = Math.Sin(termAngleRad) * Math.Sin(azRad) / cosLat;
+                var cosDLon = (Math.Cos(termAngleRad) - Math.Sin(subLatRad) * sinLat)
+                              / (Math.Cos(subLatRad) * cosLat);
+                lonRad = subLonRad + Math.Atan2(sinDLon, cosDLon);
+            }
+
+            var latDeg = latRad * 180.0 / Math.PI;
+            var lonDeg = lonRad * 180.0 / Math.PI;
+            lonDeg = ((lonDeg + 180.0) % 360.0 + 360.0) % 360.0 - 180.0;
+
+            points.Add((latDeg, lonDeg));
+        }
+
+        return points;
+    }
+
+    public static bool IsNightSide(
+        double latDeg,
+        double lonDeg,
+        double subLatDeg,
+        double subLonDeg)
+    {
+        var latRad = latDeg * Math.PI / 180.0;
+        var lonRad = lonDeg * Math.PI / 180.0;
+        var subLatRad = subLatDeg * Math.PI / 180.0;
+        var subLonRad = subLonDeg * Math.PI / 180.0;
+
+        var dLat = latRad - subLatRad;
+        var dLon = lonRad - subLonRad;
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
+              + Math.Cos(latRad) * Math.Cos(subLatRad)
+              * Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        var centralAngle = 2 * Math.Asin(Math.Sqrt(Math.Clamp(a, 0, 1)));
+        return centralAngle > Math.PI / 2.0;
+    }
+
+    private static double GetGmstRad(DateTime utc)
+    {
+        var jd = ToJulianDate(utc);
+        var t = (jd - 2451545.0) / 36525.0;
+        var gmstSec = 67310.54841
+                    + (876600.0 * 3600.0 + 8640184.812866) * t
+                    + 0.093104 * t * t
+                    - 6.2e-6 * t * t * t;
+        var gmstRad = (gmstSec % 86400.0) * 2.0 * Math.PI / 86400.0;
+        if (gmstRad < 0) gmstRad += 2.0 * Math.PI;
+        return gmstRad;
+    }
+
+    private static double ToJulianDate(DateTime utc)
+    {
+        var year = utc.Year;
+        var month = utc.Month;
+        if (month <= 2)
+        {
+            year--;
+            month += 12;
+        }
+        var century = year / 100;
+        var b = 2 - century + century / 4;
+        return Math.Floor(365.25 * (year + 4716))
+             + Math.Floor(30.6001 * (month + 1))
+             + utc.Day
+             + utc.TimeOfDay.TotalDays
+             + b
+             - 1524.5;
+    }
+}

--- a/OscarWatch/Controls/WorldMapControl.cs
+++ b/OscarWatch/Controls/WorldMapControl.cs
@@ -8,6 +8,7 @@ using Avalonia.Platform;
 using Avalonia.Threading;
 using OscarWatch.Core.Geo;
 using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
 
 namespace OscarWatch.Controls;
 
@@ -36,6 +37,9 @@ public class WorldMapControl : ThemeAwareControl
     public static readonly StyledProperty<bool> SoloFocusedSatelliteProperty =
         AvaloniaProperty.Register<WorldMapControl, bool>(nameof(SoloFocusedSatellite));
 
+    public static readonly StyledProperty<bool> ShowGraylineProperty =
+        AvaloniaProperty.Register<WorldMapControl, bool>(nameof(ShowGrayline), true);
+
     private Bitmap? _mapBitmap;
     private INotifyCollectionChanged? _trackStatesSource;
     private Size _lastLayoutInvalidationSize;
@@ -55,13 +59,20 @@ public class WorldMapControl : ThemeAwareControl
             FocusedNoradIdProperty,
             ShowFootprintMotionArrowsProperty,
             RemoteStationProperty,
-            SoloFocusedSatelliteProperty);
+            SoloFocusedSatelliteProperty,
+            ShowGraylineProperty);
     }
 
     public bool ShowFootprintMotionArrows
     {
         get => GetValue(ShowFootprintMotionArrowsProperty);
         set => SetValue(ShowFootprintMotionArrowsProperty, value);
+    }
+
+    public bool ShowGrayline
+    {
+        get => GetValue(ShowGraylineProperty);
+        set => SetValue(ShowGraylineProperty, value);
     }
 
     private const double HitRadiusPx = 16;
@@ -234,6 +245,9 @@ public class WorldMapControl : ThemeAwareControl
             context.DrawText(noMap, new Point(12, 12));
         }
 
+        if (ShowGrayline)
+            RenderGrayline(context, w, h);
+
         if (GroundStation is { } gs)
         {
             var (gx, gy) = EquirectangularProjection.GeoToPixel(gs.LatitudeDeg, gs.LongitudeDeg, w, h);
@@ -379,6 +393,101 @@ public class WorldMapControl : ThemeAwareControl
         }
 
         return bestId;
+    }
+
+    // ── Grayline ──────────────────────────────────────────────────────────
+
+    private void RenderGrayline(DrawingContext context, double w, double h)
+    {
+        var utc = DateTime.UtcNow;
+        var (subLat, subLon) = GraylineCalculator.GetSubsolarPoint(utc);
+
+        DrawNightSideOverlay(context, w, h, subLat, subLon);
+        DrawTerminatorLine(context, w, h, subLat, subLon);
+    }
+
+    private static double GetTerminatorLatitude(double lonDeg, double subLatDeg, double subLonDeg)
+    {
+        var lat = subLatDeg;
+        if (Math.Abs(lat) < 0.0001)
+            lat = lat >= 0 ? 0.0001 : -0.0001;
+
+        var subLatRad = lat * Math.PI / 180.0;
+        var lonRad = lonDeg * Math.PI / 180.0;
+        var subLonRad = subLonDeg * Math.PI / 180.0;
+
+        var termLatRad = Math.Atan(-Math.Cos(lonRad - subLonRad) / Math.Tan(subLatRad));
+        return termLatRad * 180.0 / Math.PI;
+    }
+
+    private static void DrawNightSideOverlay(
+        DrawingContext context,
+        double w,
+        double h,
+        double subLatDeg,
+        double subLonDeg)
+    {
+        var geom = new StreamGeometry();
+        using (var sgc = geom.Open())
+        {
+            var isNightBelow = subLatDeg >= 0;
+
+            var startLat = GetTerminatorLatitude(-180.0, subLatDeg, subLonDeg);
+            var (startX, startY) = EquirectangularProjection.GeoToPixel(startLat, -180.0, w, h);
+
+            sgc.BeginFigure(new Point(startX, startY), true);
+
+            const int steps = 360;
+            for (var i = 1; i <= steps; i++)
+            {
+                var lon = -180.0 + i * (360.0 / steps);
+                var lat = GetTerminatorLatitude(lon, subLatDeg, subLonDeg);
+                var (x, y) = EquirectangularProjection.GeoToPixel(lat, lon, w, h);
+                sgc.LineTo(new Point(x, y));
+            }
+
+            if (isNightBelow)
+            {
+                sgc.LineTo(new Point(w, h));
+                sgc.LineTo(new Point(0, h));
+            }
+            else
+            {
+                sgc.LineTo(new Point(w, 0));
+                sgc.LineTo(new Point(0, 0));
+            }
+        }
+
+        var nightBrush = new SolidColorBrush(Color.FromArgb(135, 2, 2, 20));
+        context.DrawGeometry(nightBrush, null, geom);
+    }
+
+    private static void DrawTerminatorLine(
+        DrawingContext context,
+        double w,
+        double h,
+        double subLatDeg,
+        double subLonDeg)
+    {
+        var ring = GraylineCalculator.GetTerminatorRingFromSubsolar(subLatDeg, subLonDeg, 720);
+        if (ring.Count < 2)
+            return;
+
+        var pen = new Pen(new SolidColorBrush(Color.FromArgb(180, 255, 220, 100)), 1.5);
+
+        var pixels = ring
+            .Select(p => EquirectangularProjection.GeoToPixel(p.LatDeg, p.LonDeg, w, h))
+            .ToList();
+
+        const double maxJump = 30;
+        for (var i = 0; i < pixels.Count - 1; i++)
+        {
+            var (x0, y0) = pixels[i];
+            var (x1, y1) = pixels[i + 1];
+            if (Math.Abs(x1 - x0) > maxJump)
+                continue;
+            context.DrawLine(pen, new Point(x0, y0), new Point(x1, y1));
+        }
     }
 
     private void EnsureMapLoaded()

--- a/OscarWatch/MainWindow.axaml
+++ b/OscarWatch/MainWindow.axaml
@@ -70,7 +70,8 @@
                                 RemoteStation="{Binding DxStation.RemoteCoordinate}"
                                 FocusedNoradId="{Binding FocusedNoradId, Mode=TwoWay}"
                                 SoloFocusedSatellite="{Binding SoloFocusedSatellite}"
-                                ShowFootprintMotionArrows="{Binding ShowFootprintMotionArrows}" />
+                                ShowFootprintMotionArrows="{Binding ShowFootprintMotionArrows}"
+                                ShowGrayline="{Binding ShowGrayline}" />
         </Grid>
         <ctrl:FrequencyOverlayControl DataContext="{Binding Frequencies}"
                                       ZIndex="1"

--- a/OscarWatch/ViewModels/MainViewModel.cs
+++ b/OscarWatch/ViewModels/MainViewModel.cs
@@ -166,6 +166,9 @@ public partial class MainViewModel : ViewModelBase
     private bool _showFootprintMotionArrows = true;
 
     [ObservableProperty]
+    private bool _showGrayline = true;
+
+    [ObservableProperty]
     private bool _isSkyPlotExpanded = true;
 
     public MainViewModel(
@@ -255,6 +258,7 @@ public partial class MainViewModel : ViewModelBase
         AppThemeManager.Apply(_settings.Current.Theme);
         RefreshGroundStationFromSettings();
         ShowFootprintMotionArrows = _settings.Current.ShowFootprintMotionArrows;
+        ShowGrayline = _settings.Current.ShowGrayline;
         IsSkyPlotExpanded = _settings.Current.SkyPlotExpanded;
         RigCatPaused = _settings.Current.Rig.CatUpdatesPaused;
 

--- a/OscarWatch/ViewModels/SettingsViewModel.cs
+++ b/OscarWatch/ViewModels/SettingsViewModel.cs
@@ -51,6 +51,9 @@ public partial class SettingsViewModel : ViewModelBase
     private bool _showFootprintMotionArrows = true;
 
     [ObservableProperty]
+    private bool _showGrayline = true;
+
+    [ObservableProperty]
     private TleSourceOption? _tleSourceOption;
 
     [ObservableProperty]
@@ -424,6 +427,7 @@ public partial class SettingsViewModel : ViewModelBase
         _settings.Current.PassPredictionHours = PassPredictionHours;
         _settings.Current.Theme = ThemePreference;
         _settings.Current.ShowFootprintMotionArrows = ShowFootprintMotionArrows;
+        _settings.Current.ShowGrayline = ShowGrayline;
         _settings.Current.TleSource = new TleSourceSettings
         {
             Mode = TleSourceOption?.Mode ?? TleSourceMode.OscarWatch,
@@ -537,6 +541,7 @@ public partial class SettingsViewModel : ViewModelBase
             PassPredictionHours = _settings.Current.PassPredictionHours;
             ThemePreference = _settings.Current.Theme;
             ShowFootprintMotionArrows = _settings.Current.ShowFootprintMotionArrows;
+            ShowGrayline = _settings.Current.ShowGrayline;
             var tleSource = _settings.Current.TleSource ?? new TleSourceSettings();
             TleSourceOption = TleSourceOptions.FirstOrDefault(o => o.Mode == tleSource.Mode)
                 ?? TleSourceOptions[0];
@@ -969,6 +974,15 @@ public partial class SettingsViewModel : ViewModelBase
 
         if (App.MainWindow?.DataContext is MainViewModel main)
             main.ShowFootprintMotionArrows = value;
+    }
+
+    partial void OnShowGraylineChanged(bool value)
+    {
+        if (_isSynchronizing)
+            return;
+
+        if (App.MainWindow?.DataContext is MainViewModel main)
+            main.ShowGrayline = value;
     }
 
     partial void OnGridSquareChanged(string value)

--- a/OscarWatch/Views/SettingsWindow.axaml
+++ b/OscarWatch/Views/SettingsWindow.axaml
@@ -175,6 +175,13 @@
                        FontSize="11"
                        TextWrapping="Wrap"
                        Text="Draws a small arrow inside each satellite footprint on the world map showing ground-track direction." />
+            <CheckBox Content="Show grayline (day/night terminator)"
+                      IsChecked="{Binding ShowGrayline, Mode=TwoWay}"
+                      Margin="0,8,0,0" />
+            <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                       FontSize="11"
+                       TextWrapping="Wrap"
+                       Text="Overlays the day/night boundary on the world map. The dark area represents the night side of Earth; a golden line marks the terminator." />
           </StackPanel>
         </ScrollViewer>
       </TabItem>


### PR DESCRIPTION
<img width="1581" height="824" alt="Screenshot_421" src="https://github.com/user-attachments/assets/7f26fe49-29d0-4981-9e68-06ca1f374c0e" />

This PR adds a day/night terminator (grayline) overlay to the world map.

**Key features:**
- Option to enable or disable the dark area in Settings -> Appearance.

I recommend taking a quick look at the changes (I'm a bit donkey 🤣)
And once again, congratulations on the project — it's excellent software.

73's de PU4ELT 🇧🇷