### PR TITLE
parallelism, caching, and shared utility functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ artifacts/
 
 ## App data (local dev only)
 *.local.json
+
+# Dave, G4DPZ Exclusions
+.kiro/

--- a/OscarWatch.Core/Geo/DayNightTerminator.cs
+++ b/OscarWatch.Core/Geo/DayNightTerminator.cs
@@ -147,33 +147,13 @@ public static class DayNightTerminator
 
     private static double GreenwichMeanSiderealTimeRadians(DateTime utc)
     {
-        var jd = ToJulianDate(utc);
+        var jd = AstronomyMath.ToJulianDate(utc);
         var t = (jd - 2451545.0) / 36525.0;
         var gmstDeg = 280.46061837
             + 360.98564736629 * (jd - 2451545.0)
             + 0.000387933 * t * t
             - t * t * t / 38710000.0;
         return NormalizeLongitudeDeg(gmstDeg) * Math.PI / 180.0;
-    }
-
-    private static double ToJulianDate(DateTime utc)
-    {
-        var year = utc.Year;
-        var month = utc.Month;
-        if (month <= 2)
-        {
-            year--;
-            month += 12;
-        }
-
-        var century = year / 100;
-        var b = 2 - century + century / 4;
-        return Math.Floor(365.25 * (year + 4716))
-            + Math.Floor(30.6001 * (month + 1))
-            + utc.Day
-            + utc.TimeOfDay.TotalDays
-            + b
-            - 1524.5;
     }
 
     private static double NormalizeLongitudeDeg(double degrees)

--- a/OscarWatch.Core/Orbit/AstronomyMath.cs
+++ b/OscarWatch.Core/Orbit/AstronomyMath.cs
@@ -1,0 +1,26 @@
+namespace OscarWatch.Core.Orbit;
+
+/// <summary>Shared astronomical utility methods used across OscarWatch.Core.</summary>
+internal static class AstronomyMath
+{
+    /// <summary>Converts a UTC <see cref="DateTime"/> to a Julian Date (JD).</summary>
+    public static double ToJulianDate(DateTime utc)
+    {
+        var year = utc.Year;
+        var month = utc.Month;
+        if (month <= 2)
+        {
+            year--;
+            month += 12;
+        }
+
+        var century = year / 100;
+        var b = 2 - century + century / 4;
+        return Math.Floor(365.25 * (year + 4716))
+            + Math.Floor(30.6001 * (month + 1))
+            + utc.Day
+            + utc.TimeOfDay.TotalDays
+            + b
+            - 1524.5;
+    }
+}

--- a/OscarWatch.Core/Orbit/IOrbitPropagator.cs
+++ b/OscarWatch.Core/Orbit/IOrbitPropagator.cs
@@ -12,5 +12,5 @@ public interface IOrbitPropagator
     EciPosition GetEciPosition(string noradId, DateTime utc);
     LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc);
     bool HasSatellite(string noradId);
-    IReadOnlyList<string> LoadedNoradIds { get; }
+    IReadOnlyCollection<string> LoadedNoradIds { get; }
 }

--- a/OscarWatch.Core/Orbit/SunPositionCalculator.cs
+++ b/OscarWatch.Core/Orbit/SunPositionCalculator.cs
@@ -9,7 +9,7 @@ public static class SunPositionCalculator
 
     public static EciPosition GetPosition(DateTime utc)
     {
-        var jd = ToJulianDate(utc);
+        var jd = AstronomyMath.ToJulianDate(utc);
         var t = (jd - 2451545.0) / 36525.0;
 
         var meanLongitudeDeg = Normalize360(280.46646 + 36000.76983 * t + 0.0003032 * t * t);
@@ -38,26 +38,6 @@ public static class SunPositionCalculator
             distanceKm * cosDec * Math.Cos(rightAscensionRad),
             distanceKm * cosDec * Math.Sin(rightAscensionRad),
             distanceKm * Math.Sin(declinationRad));
-    }
-
-    private static double ToJulianDate(DateTime utc)
-    {
-        var year = utc.Year;
-        var month = utc.Month;
-        if (month <= 2)
-        {
-            year--;
-            month += 12;
-        }
-
-        var century = year / 100;
-        var b = 2 - century + century / 4;
-        return Math.Floor(365.25 * (year + 4716))
-            + Math.Floor(30.6001 * (month + 1))
-            + utc.Day
-            + utc.TimeOfDay.TotalDays
-            + b
-            - 1524.5;
     }
 
     private static double Normalize360(double degrees)

--- a/OscarWatch.Core/Services/LiveTrackingService.cs
+++ b/OscarWatch.Core/Services/LiveTrackingService.cs
@@ -185,6 +185,7 @@ public sealed class LiveTrackingService : ILiveTrackingService
             switch (command.Kind)
             {
                 case LiveTrackingCommandKind.Reload:
+                    // Reload invalidates the cached enabled-satellite list (Req 2.4)
                     _orchestrator.ReloadEnabledSatellites();
                     RefreshSnapshot();
                     break;

--- a/OscarWatch.Core/Services/TrackingOrchestrator.cs
+++ b/OscarWatch.Core/Services/TrackingOrchestrator.cs
@@ -13,6 +13,7 @@ public sealed class TrackingOrchestrator
     private readonly IGroundGeometry _groundGeometry;
     private readonly IPassPredictor _passPredictor;
     private readonly SatelliteVisualCache _visualCache = new();
+    private IReadOnlyList<SatelliteCatalogEntry> _cachedEnabledSats = Array.Empty<SatelliteCatalogEntry>();
 
     public TrackingOrchestrator(
         ISettingsService settings,
@@ -32,7 +33,9 @@ public sealed class TrackingOrchestrator
     {
         _propagator.Clear();
         _visualCache.Clear();
-        foreach (var sat in _tleService.GetEnabledSatellites(_settings.Current))
+        var sats = _tleService.GetEnabledSatellites(_settings.Current);
+        _cachedEnabledSats = sats;
+        foreach (var sat in sats)
             _propagator.LoadSatellite(sat);
     }
 
@@ -43,7 +46,7 @@ public sealed class TrackingOrchestrator
     public IReadOnlyList<SatelliteTrackState> GetLiveStates(DateTime utc)
     {
         var site = _settings.Current.GroundStation;
-        var sats = _tleService.GetEnabledSatellites(_settings.Current);
+        var sats = _cachedEnabledSats;
         var states = new List<SatelliteTrackState>();
         var sunEci = SunPositionCalculator.GetPosition(utc);
 
@@ -159,15 +162,31 @@ public sealed class TrackingOrchestrator
         var utcEnd = utcStart.AddHours(predictionHours);
         var minDuration = TimeSpan.FromMinutes(Math.Max(0, minimumDurationMinutes));
 
-        var allPasses = new List<PassInfo>();
-        foreach (var sat in _tleService.GetEnabledSatellites(_settings.Current))
+        var sats = _tleService.GetEnabledSatellites(_settings.Current);
+        var tasks = sats.Select(sat =>
+            _passPredictor.GetPassesAsync(sat, site, utcStart, utcEnd, minimumElevationDeg, cancellationToken))
+            .ToList();
+
+        IReadOnlyList<PassInfo>[] results;
+        try
         {
-            var passes = await _passPredictor.GetPassesAsync(
-                sat, site, utcStart, utcEnd, minimumElevationDeg, cancellationToken);
-            allPasses.AddRange(passes);
+            results = await Task.WhenAll(tasks);
+        }
+        catch
+        {
+            results = tasks.Select(t =>
+                t.IsCompletedSuccessfully
+                    ? t.Result
+                    : (IReadOnlyList<PassInfo>)Array.Empty<PassInfo>())
+                .ToArray();
+            var exceptions = tasks.Where(t => t.IsFaulted)
+                                  .Select(t => t.Exception!.InnerException!)
+                                  .ToList();
+            if (exceptions.Count > 0)
+                throw new AggregateException(exceptions);
         }
 
-        return allPasses
+        return results.SelectMany(r => r)
             .Where(p => p.Duration >= minDuration)
             .OrderBy(p => p.AosUtc)
             .ToList();
@@ -187,19 +206,36 @@ public sealed class TrackingOrchestrator
         var minPassDuration = TimeSpan.FromMinutes(Math.Max(0, minimumPassDurationMinutes));
         var minMutualDuration = TimeSpan.FromMinutes(Math.Max(0, minimumMutualDurationMinutes));
 
-        var localPasses = new List<PassInfo>();
-        var remotePasses = new List<PassInfo>();
+        var sats = _tleService.GetEnabledSatellites(_settings.Current);
 
-        foreach (var sat in _tleService.GetEnabledSatellites(_settings.Current))
+        var localTasks = sats.Select(sat =>
+            _passPredictor.GetPassesAsync(sat, localSite, utcStart, utcEnd, minimumElevationDeg, cancellationToken))
+            .ToList();
+        var remoteTasks = sats.Select(sat =>
+            _passPredictor.GetPassesAsync(sat, remoteSite, utcStart, utcEnd, minimumElevationDeg, cancellationToken))
+            .ToList();
+
+        var allTasks = localTasks.Concat(remoteTasks).ToList();
+        try
         {
-            var passes = await _passPredictor.GetPassesAsync(
-                sat, localSite, utcStart, utcEnd, minimumElevationDeg, cancellationToken);
-            localPasses.AddRange(passes.Where(p => p.Duration >= minPassDuration));
-
-            passes = await _passPredictor.GetPassesAsync(
-                sat, remoteSite, utcStart, utcEnd, minimumElevationDeg, cancellationToken);
-            remotePasses.AddRange(passes.Where(p => p.Duration >= minPassDuration));
+            await Task.WhenAll(allTasks);
         }
+        catch
+        {
+            // Allow partial results to be collected below
+        }
+
+        var localPasses = localTasks
+            .Where(t => t.IsCompletedSuccessfully)
+            .SelectMany(t => t.Result)
+            .Where(p => p.Duration >= minPassDuration)
+            .ToList();
+
+        var remotePasses = remoteTasks
+            .Where(t => t.IsCompletedSuccessfully)
+            .SelectMany(t => t.Result)
+            .Where(p => p.Duration >= minPassDuration)
+            .ToList();
 
         return MutualPassFinder.FindOverlaps(localPasses, remotePasses, minMutualDuration);
     }

--- a/OscarWatch.Orbit/PassPolarPlotBuilder.cs
+++ b/OscarWatch.Orbit/PassPolarPlotBuilder.cs
@@ -146,14 +146,7 @@ public static class PassPolarPlotBuilder
         var los = propagator.GetLookAngles(satellite.NoradId, site, plotEnd);
         var maxEl = samples.Count > 0
             ? samples.Max(s => s.ElevationDeg)
-            : 0;
-
-        for (var t = plotStart; t <= plotEnd; t += SampleStep)
-        {
-            var el = propagator.GetLookAngles(satellite.NoradId, site, t).ElevationDeg;
-            if (el > maxEl)
-                maxEl = el;
-        }
+            : 0.0;
 
         return (aos.AzimuthDeg, los.AzimuthDeg, maxEl);
     }

--- a/OscarWatch.Orbit/PublicOrbitToolsPropagator.cs
+++ b/OscarWatch.Orbit/PublicOrbitToolsPropagator.cs
@@ -8,14 +8,20 @@ public sealed class PublicOrbitToolsPropagator : IOrbitPropagator
     private readonly Dictionary<string, (SatelliteCatalogEntry Entry, Zeptomoby.OrbitTools.Orbit Orbit)> _satellites =
         new(StringComparer.Ordinal);
 
-    public IReadOnlyList<string> LoadedNoradIds => _satellites.Keys.ToList();
+    private readonly Dictionary<(double, double, double), Zeptomoby.OrbitTools.Site> _siteCache = new();
+
+    public IReadOnlyCollection<string> LoadedNoradIds => _satellites.Keys;
 
     public void LoadSatellite(SatelliteCatalogEntry entry) =>
         _satellites[entry.NoradId] = (entry, OrbitToolsMapping.CreateOrbit(entry));
 
     public void RemoveSatellite(string noradId) => _satellites.Remove(noradId);
 
-    public void Clear() => _satellites.Clear();
+    public void Clear()
+    {
+        _satellites.Clear();
+        _siteCache.Clear();
+    }
 
     public bool HasSatellite(string noradId) => _satellites.ContainsKey(noradId);
 
@@ -34,7 +40,17 @@ public sealed class PublicOrbitToolsPropagator : IOrbitPropagator
     public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc)
     {
         var orbit = GetOrbit(noradId);
-        var groundSite = OrbitToolsMapping.CreateSite(site);
+        var key = (
+            Math.Round(site.LatitudeDeg,  6),
+            Math.Round(site.LongitudeDeg, 6),
+            Math.Round(site.AltitudeKm,   6));
+
+        if (!_siteCache.TryGetValue(key, out var groundSite))
+        {
+            groundSite = OrbitToolsMapping.CreateSite(site);
+            _siteCache[key] = groundSite;
+        }
+
         var satEci = orbit.PositionEci(utc);
         var topo = groundSite.GetLookAngle(satEci);
 

--- a/OscarWatch.Tests/AstronomyMathPropertyTests.cs
+++ b/OscarWatch.Tests/AstronomyMathPropertyTests.cs
@@ -1,0 +1,65 @@
+// Feature: performance-optimisations, Property 10: ToJulianDate round-trip preserves date to within 1 second
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 10.4, 10.5**
+/// </summary>
+public class AstronomyMathPropertyTests
+{
+    private static readonly long MinTicks = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+    private static readonly long MaxTicks = new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+    private static readonly long TickRange = MaxTicks - MinTicks;
+
+    /// <summary>
+    /// Property 10: ToJulianDate round-trip preserves date to within 1 second.
+    /// Generates arbitrary DateTime values in [1900-01-01, 2100-01-01] UTC,
+    /// converts to Julian Date using AstronomyMath.ToJulianDate,
+    /// converts back to DateTime using the standard JD→Calendar formula,
+    /// and asserts the round-trip result is within 1 second of the original.
+    /// </summary>
+    [Property]
+    public bool ToJulianDate_RoundTrip_PreservesDateWithin1Second(long seed)
+    {
+        // Clamp the arbitrary long into [1900-01-01, 2100-01-01] UTC tick range
+        var ticks = MinTicks + (Math.Abs(seed % TickRange));
+        var original = new DateTime(ticks, DateTimeKind.Utc);
+
+        var jd = AstronomyMath.ToJulianDate(original);
+        var roundTripped = JdToDateTime(jd);
+
+        var diff = Math.Abs((original - roundTripped).TotalSeconds);
+        return diff <= 1.0;
+    }
+
+    private static DateTime JdToDateTime(double jd)
+    {
+        var z = (int)(jd + 0.5);
+        var f = jd + 0.5 - z;
+        int a;
+        if (z < 2299161)
+            a = z;
+        else
+        {
+            var alpha = (int)((z - 1867216.25) / 36524.25);
+            a = z + 1 + alpha - alpha / 4;
+        }
+        var b2 = a + 1524;
+        var c = (int)((b2 - 122.1) / 365.25);
+        var d = (int)(365.25 * c);
+        var e = (int)((b2 - d) / 30.6001);
+        var day = b2 - d - (int)(30.6001 * e);
+        var month = e < 14 ? e - 1 : e - 13;
+        var year = month > 2 ? c - 4716 : c - 4715;
+        var fractionalDay = f;
+        var totalSeconds = fractionalDay * 86400.0;
+        var hours = (int)(totalSeconds / 3600);
+        totalSeconds -= hours * 3600;
+        var minutes = (int)(totalSeconds / 60);
+        totalSeconds -= minutes * 60;
+        return new DateTime(year, month, day, hours, minutes, (int)totalSeconds, DateTimeKind.Utc);
+    }
+}

--- a/OscarWatch.Tests/DelegatingOrbitPropagator.cs
+++ b/OscarWatch.Tests/DelegatingOrbitPropagator.cs
@@ -28,5 +28,5 @@ internal sealed class DelegatingOrbitPropagator : IOrbitPropagator
 
     public bool HasSatellite(string noradId) => _inner.HasSatellite(noradId);
 
-    public IReadOnlyList<string> LoadedNoradIds => _inner.LoadedNoradIds;
+    public IReadOnlyCollection<string> LoadedNoradIds => _inner.LoadedNoradIds;
 }

--- a/OscarWatch.Tests/EnabledSatelliteCachePropertyTests.cs
+++ b/OscarWatch.Tests/EnabledSatelliteCachePropertyTests.cs
@@ -1,0 +1,291 @@
+// Feature: performance-optimisations, Property 2: Enabled-satellite cache stability between reloads
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 2.3, 2.5**
+///
+/// Property-based tests verifying that between two <see cref="TrackingOrchestrator.ReloadEnabledSatellites"/>
+/// calls, multiple <see cref="TrackingOrchestrator.GetLiveStates"/> calls always operate on the same
+/// satellite set — no spurious additions or deletions.
+/// </summary>
+public class EnabledSatelliteCachePropertyTests
+{
+    /// <summary>
+    /// A pool of real satellite catalog entries with valid TLE data.
+    /// </summary>
+    private static readonly SatelliteCatalogEntry[] SatellitePool =
+    [
+        new()
+        {
+            Name = "ISS (ZARYA)", NoradId = "25544",
+            Line1 = "1 25544U 98067A   26141.16510469  .00005835  00000-0  11282-3 0  9994",
+            Line2 = "2 25544  51.6328  73.8715 0007529  81.3651 278.8190 15.49291753567565"
+        },
+        new()
+        {
+            Name = "AO-07", NoradId = "07530",
+            Line1 = "1 07530U 74089B   26141.31992461 -.00000054  00000-0 -48931-4 0  9992",
+            Line2 = "2 07530 101.9910 154.2858 0012269 180.6108 191.1977 12.53697584357151"
+        },
+        new()
+        {
+            Name = "AO-27", NoradId = "22825",
+            Line1 = "1 22825U 93061C   26141.14902361  .00000060  00000-0  39806-4 0  9994",
+            Line2 = "2 22825  98.6890 208.5706 0008550 172.0697 188.0622 14.30933961703139"
+        },
+        new()
+        {
+            Name = "FO-29", NoradId = "24278",
+            Line1 = "1 24278U 96046B   26141.17662052  .00000000  00000-0  34829-4 0  9991",
+            Line2 = "2 24278  98.5266 353.7450 0350115 166.3802 194.7089 13.53272915469510"
+        },
+        new()
+        {
+            Name = "SO-50", NoradId = "27607",
+            Line1 = "1 27607U 02058C   26141.24923057  .00000576  00000-0  85866-4 0  9998",
+            Line2 = "2 27607  64.5520 212.3264 0075596 267.4106  91.8345 14.82983020260469"
+        },
+        new()
+        {
+            Name = "AO-73", NoradId = "39444",
+            Line1 = "1 39444U 13066AE  26140.67569056  .00005251  00000-0  33102-3 0  9992",
+            Line2 = "2 39444  97.8265 111.5579 0034836 298.9376  60.8360 15.09093359675511"
+        },
+        new()
+        {
+            Name = "IO-86", NoradId = "40931",
+            Line1 = "1 40931U 15052B   25151.18580175  .00001241  00000-0  78118-4 0  9996",
+            Line2 = "2 40931   6.0006  24.0987 0012733 338.8432  21.1169 14.78805930523159"
+        },
+        new()
+        {
+            Name = "AO-91", NoradId = "43017",
+            Line1 = "1 43017U 17073E   26141.14920854  .00006846  00000-0  30040-3 0  9994",
+            Line2 = "2 43017  97.4737   8.9239 0153707  62.3580 299.3158 15.12168292461300"
+        },
+    ];
+
+    /// <summary>
+    /// Property 2: Enabled-satellite cache stability between reloads.
+    ///
+    /// Tests the invariant: between two ReloadEnabledSatellites calls, multiple GetLiveStates
+    /// calls should always operate on the same satellite set (as observed via LoadedNoradIds
+    /// on the propagator, which reflects what was loaded during reload).
+    ///
+    /// Strategy:
+    /// - Pick an arbitrary subset of satellites to enable (via subsetMask).
+    /// - Create a TrackingOrchestrator with a mock ITleService returning that subset.
+    /// - Call ReloadEnabledSatellites once.
+    /// - Call GetLiveStates N times (getLiveStatesCalls, 1-10).
+    /// - Assert LoadedNoradIds stays the same set on every call.
+    /// </summary>
+    [Property]
+    public bool Cache_is_stable_between_reloads(
+        bool[] subsetMask,
+        byte getLiveStatesCallsByte)
+    {
+        if (subsetMask is null || subsetMask.Length == 0)
+            return true; // trivially true for empty inputs
+
+        // Build the enabled satellite list from the subset mask
+        var enabledSats = new List<SatelliteCatalogEntry>();
+        for (var i = 0; i < subsetMask.Length && i < SatellitePool.Length; i++)
+        {
+            if (subsetMask[i])
+                enabledSats.Add(SatellitePool[i]);
+        }
+
+        if (enabledSats.Count == 0)
+            return true; // nothing to test with no enabled sats
+
+        // Map the byte to a call count of 1-10
+        var getLiveStatesCalls = (getLiveStatesCallsByte % 10) + 1;
+
+        // Set up the orchestrator with a mock TLE service that returns our fixed list
+        var settings = new StubSettingsService();
+        var tleService = new StubTleService(enabledSats);
+        var propagator = new TrackingPropagator();
+        var groundGeometry = new StubGroundGeometry();
+        var passPredictor = new StubPassPredictor();
+
+        var orchestrator = new TrackingOrchestrator(
+            settings, tleService, propagator, groundGeometry, passPredictor);
+
+        // Perform a single reload — this populates the cache
+        orchestrator.ReloadEnabledSatellites();
+
+        // Capture the initial set of loaded NORAD IDs
+        var expectedIds = new HashSet<string>(propagator.LoadedNoradIds, StringComparer.Ordinal);
+
+        // Call GetLiveStates multiple times; assert that the propagator's loaded set
+        // (which reflects what _cachedEnabledSats contains) never changes
+        var utc = new DateTime(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        for (var i = 0; i < getLiveStatesCalls; i++)
+        {
+            var states = orchestrator.GetLiveStates(utc.AddSeconds(i));
+
+            // The propagator's loaded set should not have changed
+            var currentIds = new HashSet<string>(propagator.LoadedNoradIds, StringComparer.Ordinal);
+            if (!currentIds.SetEquals(expectedIds))
+                return false;
+
+            // The returned states should only contain satellites from the enabled set
+            foreach (var state in states)
+            {
+                if (!expectedIds.Contains(state.NoradId))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Property 2b: After a reload, GetLiveStates returns the same NORAD IDs
+    /// regardless of how many times it is called (idempotence of cache reads).
+    ///
+    /// This is a stronger form: we check not just the propagator state but
+    /// the actual NORAD IDs returned in the track states.
+    /// </summary>
+    [Property]
+    public bool GetLiveStates_returns_consistent_norad_ids_between_reloads(
+        bool[] subsetMask,
+        byte callCountByte)
+    {
+        if (subsetMask is null || subsetMask.Length == 0)
+            return true;
+
+        var enabledSats = new List<SatelliteCatalogEntry>();
+        for (var i = 0; i < subsetMask.Length && i < SatellitePool.Length; i++)
+        {
+            if (subsetMask[i])
+                enabledSats.Add(SatellitePool[i]);
+        }
+
+        if (enabledSats.Count == 0)
+            return true;
+
+        var callCount = (callCountByte % 10) + 1;
+
+        var settings = new StubSettingsService();
+        var tleService = new StubTleService(enabledSats);
+        var propagator = new TrackingPropagator();
+        var groundGeometry = new StubGroundGeometry();
+        var passPredictor = new StubPassPredictor();
+
+        var orchestrator = new TrackingOrchestrator(
+            settings, tleService, propagator, groundGeometry, passPredictor);
+
+        orchestrator.ReloadEnabledSatellites();
+
+        var utc = new DateTime(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        // Get the NORAD IDs from the first call
+        var firstStates = orchestrator.GetLiveStates(utc);
+        var firstNoradIds = new HashSet<string>(
+            firstStates.Select(s => s.NoradId), StringComparer.Ordinal);
+
+        // All subsequent calls should return the same set of NORAD IDs
+        for (var i = 1; i < callCount; i++)
+        {
+            var states = orchestrator.GetLiveStates(utc.AddSeconds(i));
+            var currentNoradIds = new HashSet<string>(
+                states.Select(s => s.NoradId), StringComparer.Ordinal);
+
+            if (!currentNoradIds.SetEquals(firstNoradIds))
+                return false;
+        }
+
+        return true;
+    }
+
+    #region Test Doubles
+
+    private sealed class StubSettingsService : ISettingsService
+    {
+        public AppSettings Current { get; } = new();
+        public string SettingsPath { get; } = "";
+        public void Load() { }
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SaveAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void RequestSave() { }
+        public void SyncGridFromLatLon() { }
+        public void SyncLatLonFromGrid() { }
+        public void EnsureSavedStations() { }
+        public void ApplyActiveStation() { }
+        public void SyncActiveStationFromGroundStation() { }
+    }
+
+    /// <summary>
+    /// A stub TLE service that always returns a fixed list of enabled satellites,
+    /// regardless of settings. This allows us to control exactly which satellites
+    /// the orchestrator sees during the test.
+    /// </summary>
+    private sealed class StubTleService : ITleService
+    {
+        private readonly IReadOnlyList<SatelliteCatalogEntry> _enabled;
+
+        public StubTleService(IReadOnlyList<SatelliteCatalogEntry> enabled)
+        {
+            _enabled = enabled;
+        }
+
+        public IReadOnlyList<SatelliteCatalogEntry> Catalog => _enabled;
+        public DateTime? LastFetchedUtc => DateTime.UtcNow;
+        public string CachePath => "";
+        public bool IsStale(int staleHours) => false;
+        public Task RefreshAsync(bool force = false, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void InvalidateCatalog() { }
+        public string ActiveSourceLabel => "Test";
+        public IReadOnlyList<SatelliteCatalogEntry> GetEnabledSatellites(AppSettings settings) => _enabled;
+    }
+
+    /// <summary>
+    /// A propagator that tracks loaded satellites and returns simple subpoints/ECI positions
+    /// without performing real SGP4 propagation. This keeps the test fast and focused
+    /// on cache stability rather than orbital mechanics.
+    /// </summary>
+    private sealed class TrackingPropagator : IOrbitPropagator
+    {
+        private readonly Dictionary<string, SatelliteCatalogEntry> _loaded = new(StringComparer.Ordinal);
+
+        public IReadOnlyCollection<string> LoadedNoradIds => _loaded.Keys;
+
+        public void LoadSatellite(SatelliteCatalogEntry entry) => _loaded[entry.NoradId] = entry;
+        public void RemoveSatellite(string noradId) => _loaded.Remove(noradId);
+        public void Clear() => _loaded.Clear();
+        public bool HasSatellite(string noradId) => _loaded.ContainsKey(noradId);
+
+        public GeoCoordinate GetSubpoint(string noradId, DateTime utc) => new(0, 0, 400);
+        public EciPosition GetEciPosition(string noradId, DateTime utc) => new(6778, 0, 0);
+        public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc) => new(180, 45, 1000, 0);
+    }
+
+    private sealed class StubGroundGeometry : IGroundGeometry
+    {
+        public IReadOnlyList<GeoCoordinate> GetGroundTrack(
+            SatelliteCatalogEntry satellite, DateTime utcStart, DateTime utcEnd, TimeSpan step) => [];
+
+        public IReadOnlyList<GeoCoordinate> GetFootprint(
+            SatelliteCatalogEntry satellite, DateTime utc, double minimumElevationDeg) => [];
+    }
+
+    private sealed class StubPassPredictor : IPassPredictor
+    {
+        public Task<IReadOnlyList<PassInfo>> GetPassesAsync(
+            SatelliteCatalogEntry satellite, GroundStation site,
+            DateTime utcStart, DateTime utcEnd, double minimumElevationDeg,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<PassInfo>>([]);
+    }
+
+    #endregion
+}

--- a/OscarWatch.Tests/FsCheckSmokeTests.cs
+++ b/OscarWatch.Tests/FsCheckSmokeTests.cs
@@ -1,0 +1,15 @@
+// Feature: performance-optimisations — FsCheck infrastructure smoke tests
+
+using FsCheck;
+using FsCheck.Xunit;
+
+namespace OscarWatch.Tests;
+
+public class FsCheckSmokeTests
+{
+    [Property]
+    public bool IntegerIdentity(int x) => x == x;
+
+    [Property]
+    public bool StringLengthNonNegative(string s) => s.Length >= 0;
+}

--- a/OscarWatch.Tests/LiveTrackingServiceTests.cs
+++ b/OscarWatch.Tests/LiveTrackingServiceTests.cs
@@ -118,7 +118,7 @@ public sealed class LiveTrackingServiceTests
 
     private sealed class NullOrbitPropagator : Core.Orbit.IOrbitPropagator
     {
-        public IReadOnlyList<string> LoadedNoradIds { get; } = [];
+        public IReadOnlyCollection<string> LoadedNoradIds { get; } = [];
         public void Clear() { }
         public void LoadSatellite(SatelliteCatalogEntry entry) { }
         public void RemoveSatellite(string noradId) { }

--- a/OscarWatch.Tests/LoadedNoradIdsPropertyTests.cs
+++ b/OscarWatch.Tests/LoadedNoradIdsPropertyTests.cs
@@ -1,0 +1,126 @@
+// Feature: performance-optimisations, Property 11: LoadedNoradIds accurately reflects the loaded satellite set
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 11.3**
+///
+/// Property-based tests verifying that <see cref="PublicOrbitToolsPropagator.LoadedNoradIds"/>
+/// accurately reflects the set of satellites loaded via LoadSatellite/RemoveSatellite operations.
+/// </summary>
+public class LoadedNoradIdsPropertyTests
+{
+    /// <summary>
+    /// A pool of real satellite catalog entries with valid TLE data.
+    /// We use these to avoid needing to generate arbitrary valid TLE lines.
+    /// </summary>
+    private static readonly SatelliteCatalogEntry[] SatellitePool =
+    [
+        new()
+        {
+            Name = "ISS (ZARYA)", NoradId = "25544",
+            Line1 = "1 25544U 98067A   26141.16510469  .00005835  00000-0  11282-3 0  9994",
+            Line2 = "2 25544  51.6328  73.8715 0007529  81.3651 278.8190 15.49291753567565"
+        },
+        new()
+        {
+            Name = "AO-07", NoradId = "07530",
+            Line1 = "1 07530U 74089B   26141.31992461 -.00000054  00000-0 -48931-4 0  9992",
+            Line2 = "2 07530 101.9910 154.2858 0012269 180.6108 191.1977 12.53697584357151"
+        },
+        new()
+        {
+            Name = "AO-27", NoradId = "22825",
+            Line1 = "1 22825U 93061C   26141.14902361  .00000060  00000-0  39806-4 0  9994",
+            Line2 = "2 22825  98.6890 208.5706 0008550 172.0697 188.0622 14.30933961703139"
+        },
+        new()
+        {
+            Name = "FO-29", NoradId = "24278",
+            Line1 = "1 24278U 96046B   26141.17662052  .00000000  00000-0  34829-4 0  9991",
+            Line2 = "2 24278  98.5266 353.7450 0350115 166.3802 194.7089 13.53272915469510"
+        },
+        new()
+        {
+            Name = "SO-50", NoradId = "27607",
+            Line1 = "1 27607U 02058C   26141.24923057  .00000576  00000-0  85866-4 0  9998",
+            Line2 = "2 27607  64.5520 212.3264 0075596 267.4106  91.8345 14.82983020260469"
+        },
+        new()
+        {
+            Name = "AO-73", NoradId = "39444",
+            Line1 = "1 39444U 13066AE  26140.67569056  .00005251  00000-0  33102-3 0  9992",
+            Line2 = "2 39444  97.8265 111.5579 0034836 298.9376  60.8360 15.09093359675511"
+        },
+        new()
+        {
+            Name = "IO-86", NoradId = "40931",
+            Line1 = "1 40931U 15052B   25151.18580175  .00001241  00000-0  78118-4 0  9996",
+            Line2 = "2 40931   6.0006  24.0987 0012733 338.8432  21.1169 14.78805930523159"
+        },
+        new()
+        {
+            Name = "AO-91", NoradId = "43017",
+            Line1 = "1 43017U 17073E   26141.14920854  .00006846  00000-0  30040-3 0  9994",
+            Line2 = "2 43017  97.4737   8.9239 0153707  62.3580 299.3158 15.12168292461300"
+        },
+    ];
+
+    /// <summary>
+    /// Property 11: LoadedNoradIds accurately reflects the loaded satellite set.
+    ///
+    /// Generates arbitrary sequences of LoadSatellite/RemoveSatellite operations
+    /// (encoded as parallel bool[] and int[] arrays), applies each to a
+    /// PublicOrbitToolsPropagator, and after all operations asserts LoadedNoradIds
+    /// set equals the expected set.
+    ///
+    /// FsCheck generates the bool[] (isLoad decisions) and int[] (pool indices)
+    /// automatically. We zip them together to form the operation sequence.
+    /// </summary>
+    [Property]
+    public bool LoadedNoradIds_reflects_loaded_satellite_set_after_operations(
+        bool[] isLoadOps, int[] poolIndices)
+    {
+        if (isLoadOps is null || isLoadOps.Length == 0 ||
+            poolIndices is null || poolIndices.Length == 0)
+            return true; // trivially true for empty inputs
+
+        var propagator = new PublicOrbitToolsPropagator();
+        var expected = new HashSet<string>(StringComparer.Ordinal);
+
+        var opCount = Math.Min(isLoadOps.Length, poolIndices.Length);
+
+        for (var i = 0; i < opCount; i++)
+        {
+            // Map arbitrary int to a valid pool index
+            var poolIndex = ((poolIndices[i] % SatellitePool.Length) + SatellitePool.Length)
+                            % SatellitePool.Length;
+            var entry = SatellitePool[poolIndex];
+
+            if (isLoadOps[i])
+            {
+                propagator.LoadSatellite(entry);
+                expected.Add(entry.NoradId);
+            }
+            else
+            {
+                propagator.RemoveSatellite(entry.NoradId);
+                expected.Remove(entry.NoradId);
+            }
+        }
+
+        var loadedIds = propagator.LoadedNoradIds;
+
+        // Count must match
+        if (loadedIds.Count != expected.Count)
+            return false;
+
+        // Contents must match
+        var actualSet = new HashSet<string>(loadedIds, StringComparer.Ordinal);
+        return actualSet.SetEquals(expected);
+    }
+}

--- a/OscarWatch.Tests/MaxElevationPropertyTests.cs
+++ b/OscarWatch.Tests/MaxElevationPropertyTests.cs
@@ -1,0 +1,92 @@
+// Feature: performance-optimisations, Property 3: MaxElevationDeg equals sample maximum
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.4**
+///
+/// Property-based tests verifying that <see cref="PassPolarPlotBuilder.Build"/>
+/// produces a <c>MaxElevationDeg</c> value that equals the maximum <c>ElevationDeg</c>
+/// found in the <c>Samples</c> array when <c>useFullPass</c> is false and samples are non-empty.
+/// </summary>
+public class MaxElevationPropertyTests
+{
+    private static readonly SatelliteCatalogEntry IssSatellite = new()
+    {
+        Name = "ISS (ZARYA)",
+        NoradId = "25544",
+        Line1 = "1 25544U 98067A   25205.51782528  .00016717  00000+0  10270-3 0  9993",
+        Line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.50415322908603"
+    };
+
+    private static readonly GroundStation London = new()
+    {
+        DisplayName = "London",
+        LatitudeDeg = 51.5,
+        LongitudeDeg = -0.1,
+        AltitudeMetersAsl = 50,
+        GridSquare = "IO91"
+    };
+
+    /// <summary>
+    /// Property 3: MaxElevationDeg equals sample maximum.
+    ///
+    /// Uses real ISS TLE and a real pass prediction to build polar plot data with
+    /// useFullPass = false (mutual-window-only mode). Asserts that MaxElevationDeg
+    /// matches the maximum ElevationDeg found in the Samples collection within 0.001°.
+    ///
+    /// The property is tested with arbitrary offsets into the mutual window to exercise
+    /// different sub-windows of the pass.
+    /// </summary>
+    [Property]
+    public bool MaxElevationDeg_equals_sample_maximum_when_useFullPass_is_false(byte offsetByte)
+    {
+        // Use a fixed time window known to produce ISS passes over London
+        var utcStart = new DateTime(2026, 5, 23, 0, 0, 0, DateTimeKind.Utc);
+        var predictor = new BruteForcePassPredictor();
+        var passes = predictor.GetPassesAsync(
+            IssSatellite,
+            London,
+            utcStart,
+            utcStart.AddDays(2),
+            minimumElevationDeg: 5).GetAwaiter().GetResult();
+
+        if (passes.Count == 0)
+            return true; // vacuously true if no passes found
+
+        var pass = passes[0];
+        var propagator = new PublicOrbitToolsPropagator();
+        propagator.LoadSatellite(IssSatellite);
+
+        // Use the offset byte to generate different mutual windows within the pass
+        var passDuration = (pass.LosUtc - pass.AosUtc).TotalSeconds;
+        var startOffset = (offsetByte % 50) / 100.0 * passDuration;
+        var endOffset = (offsetByte % 30) / 100.0 * passDuration;
+
+        var mutualStart = pass.AosUtc.AddSeconds(startOffset);
+        var mutualEnd = pass.LosUtc.AddSeconds(-endOffset);
+
+        // Ensure mutual window is valid
+        if (mutualEnd <= mutualStart)
+            return true; // skip degenerate windows
+
+        var plot = PassPolarPlotBuilder.Build(
+            IssSatellite,
+            propagator,
+            London,
+            pass,
+            useFullPass: false,
+            mutualStart,
+            mutualEnd);
+
+        if (plot.Samples.Count == 0)
+            return true; // vacuously true if no samples
+
+        var sampleMax = plot.Samples.Max(s => s.ElevationDeg);
+        return Math.Abs(plot.MaxElevationDeg - sampleMax) < 0.001;
+    }
+}

--- a/OscarWatch.Tests/OscarWatch.Tests.csproj
+++ b/OscarWatch.Tests/OscarWatch.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OscarWatch.Core\OscarWatch.Core.csproj" />

--- a/OscarWatch.Tests/ParallelPassPredictionPropertyTests.cs
+++ b/OscarWatch.Tests/ParallelPassPredictionPropertyTests.cs
@@ -1,0 +1,274 @@
+// Feature: performance-optimisations, Property 1: Parallel pass prediction preserves sorted, filtered output
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 1.2, 1.5**
+///
+/// Property-based tests verifying that <see cref="TrackingOrchestrator.GetPassesAsync"/>
+/// always returns results sorted by AOS time, and that the count matches the total of
+/// all predictions meeting the minimum duration filter.
+/// </summary>
+public class ParallelPassPredictionPropertyTests
+{
+    /// <summary>
+    /// A pool of real satellite catalog entries with valid TLE data.
+    /// </summary>
+    private static readonly SatelliteCatalogEntry[] SatellitePool =
+    [
+        new()
+        {
+            Name = "ISS (ZARYA)", NoradId = "25544",
+            Line1 = "1 25544U 98067A   26141.16510469  .00005835  00000-0  11282-3 0  9994",
+            Line2 = "2 25544  51.6328  73.8715 0007529  81.3651 278.8190 15.49291753567565"
+        },
+        new()
+        {
+            Name = "AO-07", NoradId = "07530",
+            Line1 = "1 07530U 74089B   26141.31992461 -.00000054  00000-0  -48931-4 0  9992",
+            Line2 = "2 07530 101.9910 154.2858 0012269 180.6108 191.1977 12.53697584357151"
+        },
+        new()
+        {
+            Name = "AO-27", NoradId = "22825",
+            Line1 = "1 22825U 93061C   26141.14902361  .00000060  00000-0  39806-4 0  9994",
+            Line2 = "2 22825  98.6890 208.5706 0008550 172.0697 188.0622 14.30933961703139"
+        },
+        new()
+        {
+            Name = "FO-29", NoradId = "24278",
+            Line1 = "1 24278U 96046B   26141.17662052  .00000000  00000-0  34829-4 0  9991",
+            Line2 = "2 24278  98.5266 353.7450 0350115 166.3802 194.7089 13.53272915469510"
+        },
+        new()
+        {
+            Name = "SO-50", NoradId = "27607",
+            Line1 = "1 27607U 02058C   26141.24923057  .00000576  00000-0  85866-4 0  9998",
+            Line2 = "2 27607  64.5520 212.3264 0075596 267.4106  91.8345 14.82983020260469"
+        },
+        new()
+        {
+            Name = "AO-73", NoradId = "39444",
+            Line1 = "1 39444U 13066AE  26140.67569056  .00005251  00000-0  33102-3 0  9992",
+            Line2 = "2 39444  97.8265 111.5579 0034836 298.9376  60.8360 15.09093359675511"
+        },
+        new()
+        {
+            Name = "IO-86", NoradId = "40931",
+            Line1 = "1 40931U 15052B   25151.18580175  .00001241  00000-0  78118-4 0  9996",
+            Line2 = "2 40931   6.0006  24.0987 0012733 338.8432  21.1169 14.78805930523159"
+        },
+        new()
+        {
+            Name = "AO-91", NoradId = "43017",
+            Line1 = "1 43017U 17073E   26141.14920854  .00006846  00000-0  30040-3 0  9994",
+            Line2 = "2 43017  97.4737   8.9239 0153707  62.3580 299.3158 15.12168292461300"
+        },
+    ];
+
+    /// <summary>
+    /// Property 1: Parallel pass prediction preserves sorted, filtered output.
+    ///
+    /// Strategy:
+    /// - Pick an arbitrary subset of satellites (1-8 via subsetMask).
+    /// - For each satellite, generate a set of fake passes with random AOS times.
+    /// - Create a <see cref="FakePassPredictor"/> that returns those passes.
+    /// - Call <see cref="TrackingOrchestrator.GetPassesAsync"/>.
+    /// - Assert: the returned list is sorted by AosUtc.
+    /// - Assert: the returned count equals the total passes that meet the minimum duration filter.
+    /// </summary>
+    [Property]
+    public bool Output_is_sorted_by_AOS_and_count_matches_filtered_total(
+        bool[] subsetMask,
+        byte[] aosOffsetMinutes,
+        byte durationMinutesByte)
+    {
+        if (subsetMask is null || subsetMask.Length == 0)
+            return true;
+        if (aosOffsetMinutes is null || aosOffsetMinutes.Length == 0)
+            return true;
+
+        // Build the enabled satellite list from the subset mask (1-8 satellites)
+        var enabledSats = new List<SatelliteCatalogEntry>();
+        for (var i = 0; i < subsetMask.Length && i < SatellitePool.Length; i++)
+        {
+            if (subsetMask[i])
+                enabledSats.Add(SatellitePool[i]);
+        }
+
+        if (enabledSats.Count == 0)
+            return true; // trivially true for empty inputs
+
+        // Map the duration byte to a minimum duration of 0-5 minutes
+        var minimumDurationMinutes = durationMinutesByte % 6;
+
+        // Build fake passes for each satellite using the AOS offsets
+        var baseTime = new DateTime(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var passesBySatellite = new Dictionary<string, List<PassInfo>>();
+        var aosIndex = 0;
+
+        foreach (var sat in enabledSats)
+        {
+            var passes = new List<PassInfo>();
+            // Each satellite gets 1-3 passes depending on available offsets
+            var passCount = Math.Min(3, aosOffsetMinutes.Length - aosIndex);
+            if (passCount <= 0) passCount = 1;
+
+            for (var p = 0; p < passCount && aosIndex < aosOffsetMinutes.Length; p++)
+            {
+                var aosOffset = aosOffsetMinutes[aosIndex++];
+                var aos = baseTime.AddMinutes(aosOffset);
+                // Duration: 3-10 minutes based on offset value
+                var durationMin = 3 + (aosOffset % 8);
+                var los = aos.AddMinutes(durationMin);
+
+                passes.Add(new PassInfo
+                {
+                    SatelliteName = sat.Name,
+                    NoradId = sat.NoradId,
+                    AosUtc = aos,
+                    LosUtc = los,
+                    MaxElevationDeg = 15.0 + (aosOffset % 60),
+                    MaxElevationUtc = aos.AddMinutes(durationMin / 2.0),
+                    AosAzimuthDeg = 90.0,
+                    LosAzimuthDeg = 270.0
+                });
+            }
+
+            passesBySatellite[sat.NoradId] = passes;
+        }
+
+        // Set up the orchestrator with the fake predictor
+        var settings = new StubSettingsService();
+        var tleService = new StubTleService(enabledSats);
+        var propagator = new TrackingPropagator();
+        var groundGeometry = new StubGroundGeometry();
+        var passPredictor = new FakePassPredictor(passesBySatellite);
+
+        var orchestrator = new TrackingOrchestrator(
+            settings, tleService, propagator, groundGeometry, passPredictor);
+
+        // Call GetPassesAsync
+        var site = new GroundStation();
+        var minDuration = TimeSpan.FromMinutes(minimumDurationMinutes);
+        var result = orchestrator.GetPassesAsync(
+            site,
+            minimumElevationDeg: 5.0,
+            predictionHours: 24,
+            minimumDurationMinutes: minimumDurationMinutes,
+            CancellationToken.None).GetAwaiter().GetResult();
+
+        // Assert 1: output is sorted by AosUtc
+        for (var i = 1; i < result.Count; i++)
+        {
+            if (result[i].AosUtc < result[i - 1].AosUtc)
+                return false;
+        }
+
+        // Assert 2: count matches total of all predictions that meet the minimum duration filter
+        var expectedCount = passesBySatellite.Values
+            .SelectMany(p => p)
+            .Count(p => p.Duration >= minDuration);
+
+        if (result.Count != expectedCount)
+            return false;
+
+        return true;
+    }
+
+    #region Test Doubles
+
+    private sealed class StubSettingsService : ISettingsService
+    {
+        public AppSettings Current { get; } = new();
+        public string SettingsPath { get; } = "";
+        public void Load() { }
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SaveAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void RequestSave() { }
+        public void SyncGridFromLatLon() { }
+        public void SyncLatLonFromGrid() { }
+        public void EnsureSavedStations() { }
+        public void ApplyActiveStation() { }
+        public void SyncActiveStationFromGroundStation() { }
+    }
+
+    private sealed class StubTleService : ITleService
+    {
+        private readonly IReadOnlyList<SatelliteCatalogEntry> _enabled;
+
+        public StubTleService(IReadOnlyList<SatelliteCatalogEntry> enabled)
+        {
+            _enabled = enabled;
+        }
+
+        public IReadOnlyList<SatelliteCatalogEntry> Catalog => _enabled;
+        public DateTime? LastFetchedUtc => DateTime.UtcNow;
+        public string CachePath => "";
+        public bool IsStale(int staleHours) => false;
+        public Task RefreshAsync(bool force = false, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void InvalidateCatalog() { }
+        public string ActiveSourceLabel => "Test";
+        public IReadOnlyList<SatelliteCatalogEntry> GetEnabledSatellites(AppSettings settings) => _enabled;
+    }
+
+    private sealed class TrackingPropagator : IOrbitPropagator
+    {
+        private readonly Dictionary<string, SatelliteCatalogEntry> _loaded = new(StringComparer.Ordinal);
+
+        public IReadOnlyCollection<string> LoadedNoradIds => _loaded.Keys;
+
+        public void LoadSatellite(SatelliteCatalogEntry entry) => _loaded[entry.NoradId] = entry;
+        public void RemoveSatellite(string noradId) => _loaded.Remove(noradId);
+        public void Clear() => _loaded.Clear();
+        public bool HasSatellite(string noradId) => _loaded.ContainsKey(noradId);
+
+        public GeoCoordinate GetSubpoint(string noradId, DateTime utc) => new(0, 0, 400);
+        public EciPosition GetEciPosition(string noradId, DateTime utc) => new(6778, 0, 0);
+        public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc) => new(180, 45, 1000, 0);
+    }
+
+    private sealed class StubGroundGeometry : IGroundGeometry
+    {
+        public IReadOnlyList<GeoCoordinate> GetGroundTrack(
+            SatelliteCatalogEntry satellite, DateTime utcStart, DateTime utcEnd, TimeSpan step) => [];
+
+        public IReadOnlyList<GeoCoordinate> GetFootprint(
+            SatelliteCatalogEntry satellite, DateTime utc, double minimumElevationDeg) => [];
+    }
+
+    /// <summary>
+    /// A fake pass predictor that returns pre-configured passes per satellite NORAD ID.
+    /// This allows the property test to control exactly what passes are returned and
+    /// verify that the orchestrator correctly aggregates, filters, and sorts them.
+    /// </summary>
+    private sealed class FakePassPredictor : IPassPredictor
+    {
+        private readonly Dictionary<string, List<PassInfo>> _passesBySatellite;
+
+        public FakePassPredictor(Dictionary<string, List<PassInfo>> passesBySatellite)
+        {
+            _passesBySatellite = passesBySatellite;
+        }
+
+        public Task<IReadOnlyList<PassInfo>> GetPassesAsync(
+            SatelliteCatalogEntry satellite, GroundStation site,
+            DateTime utcStart, DateTime utcEnd, double minimumElevationDeg,
+            CancellationToken cancellationToken = default)
+        {
+            if (_passesBySatellite.TryGetValue(satellite.NoradId, out var passes))
+                return Task.FromResult<IReadOnlyList<PassInfo>>(passes);
+
+            return Task.FromResult<IReadOnlyList<PassInfo>>([]);
+        }
+    }
+
+    #endregion
+}

--- a/OscarWatch.Tests/SiteCachePropertyTests.cs
+++ b/OscarWatch.Tests/SiteCachePropertyTests.cs
@@ -1,0 +1,60 @@
+// Feature: performance-optimisations, Property 4: Site cache does not alter look-angle results
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 4.5**
+///
+/// Property-based tests verifying that the <see cref="PublicOrbitToolsPropagator"/>
+/// Site cache does not alter look-angle results. Two successive calls with the same
+/// inputs must return identical AzimuthDeg, ElevationDeg, and RangeKm values.
+/// </summary>
+public class SiteCachePropertyTests
+{
+    private static readonly SatelliteCatalogEntry IssSatellite = new()
+    {
+        Name = "ISS (ZARYA)",
+        NoradId = "25544",
+        Line1 = "1 25544U 98067A   26141.16510469  .00005835  00000-0  11282-3 0  9994",
+        Line2 = "2 25544  51.6328  73.8715 0007529  81.3651 278.8190 15.49291753567565"
+    };
+
+    private static readonly DateTime FixedUtc = new(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Property 4: Site cache does not alter look-angle results.
+    ///
+    /// Generates arbitrary (lat, lon, alt) tuples within valid ranges and asserts that
+    /// calling GetLookAngles twice in succession with the same inputs returns identical results.
+    /// This proves the cache doesn't corrupt results.
+    /// </summary>
+    [Property]
+    public bool Site_cache_does_not_alter_look_angle_results(int latInt, int lonInt, int altInt)
+    {
+        // Map integers to valid ranges to avoid NaN/Infinity issues with raw doubles
+        var lat = (latInt % 9000) / 100.0;   // [-90, 90] degrees
+        var lon = (lonInt % 18000) / 100.0;  // [-180, 180] degrees
+        var alt = Math.Abs(altInt % 1000) / 1000.0; // [0, 1] km
+
+        var propagator = new PublicOrbitToolsPropagator();
+        propagator.LoadSatellite(IssSatellite);
+
+        var groundStation = new GroundStation
+        {
+            LatitudeDeg = lat,
+            LongitudeDeg = lon,
+            AltitudeMetersAsl = alt * 1000.0 // Convert km to meters
+        };
+
+        var first = propagator.GetLookAngles(IssSatellite.NoradId, groundStation, FixedUtc);
+        var second = propagator.GetLookAngles(IssSatellite.NoradId, groundStation, FixedUtc);
+
+        return first.AzimuthDeg == second.AzimuthDeg
+            && first.ElevationDeg == second.ElevationDeg
+            && first.RangeKm == second.RangeKm;
+    }
+}


### PR DESCRIPTION
Hi

Added a few performence updates and helpers

- Extract shared AstronomyMath.ToJulianDate utility
- Expose LoadedNoradIds as IReadOnlyCollection without allocation
- Cache Site object in PublicOrbitToolsPropagator
- Parallel pass prediction via Task.WhenAll fan-out
- Cache enabled-satellite list in TrackingOrchestrator
- Derive max elevation from sample list in PassPolarPlotBuilder
- Add FsCheck.Xunit 3.0.0 and property-based tests for all changes

Now 436 tests