### PR TITLE
fix: TS-2000 satellite mode entry with settling delay and SA; retry

### DIFF
--- a/OscarWatch.Tests/SatelliteModeBugConditionPropertyTests.cs
+++ b/OscarWatch.Tests/SatelliteModeBugConditionPropertyTests.cs
@@ -1,0 +1,115 @@
+// Feature: ts2000-satmode-entry-fix, Property 1: Bug Condition — Silent SATL Confirmation Override
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Radio;
+using OscarWatch.Rig;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+///
+/// Bug condition exploration test: demonstrates that when SetSatelliteMode(true) is called
+/// on an open transport where the radio does NOT confirm SATL (SA; returns SA0; or null),
+/// the unfixed code incorrectly sets IsSatelliteModeActive = true via the resilience override.
+///
+/// Expected behavior (design): IsSatelliteModeActive should be false when the radio
+/// does not confirm satellite mode active.
+///
+/// This test is EXPECTED TO FAIL on unfixed code — failure confirms the bug exists.
+/// </summary>
+public class SatelliteModeBugConditionPropertyTests
+{
+    /// <summary>
+    /// Property 1: Bug Condition — Silent SATL Confirmation Override
+    ///
+    /// For any SetSatelliteMode(true) call on an open transport where SA; returns SA0;
+    /// (radio not confirming SATL), IsSatelliteModeActive MUST be false.
+    ///
+    /// The unfixed code will return true because the resilience override sets
+    /// _satelliteMode = true regardless — this is the counterexample.
+    ///
+    /// Also verifies:
+    /// - No settling delay is present after SA1010110; (command log shows immediate handshake)
+    /// - No retry attempts are made for SA; verification (only one SA; in command log)
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool SatelliteMode_not_active_when_radio_does_not_confirm_SATL(bool returnNull)
+    {
+        // Arrange: transport that simulates radio NOT ready (never confirms SATL)
+        var transport = new NonConfirmingSatelliteTransport(returnNull);
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0, satModeSettlingDelayMs: 0, satModeRetryCount: 3, satModeRetryDelayMs: 0);
+        driver.Open();
+
+        // Act: attempt satellite mode entry
+        driver.SetSatelliteMode(true);
+
+        // Assert expected behavior:
+        // 1. IsSatelliteModeActive should be false (radio didn't confirm)
+        if (driver.IsSatelliteModeActive)
+            return false;
+
+        // 2. Multiple SA; queries in command log (retries were attempted)
+        var saQueryCount = transport.SentCommands.Count(c => c == "SA;");
+        if (saQueryCount != 3) // default retry count
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Transport that simulates a radio that has NOT confirmed satellite mode.
+    /// Unlike RecordingKenwoodCatTransport, this does NOT auto-flip SatelliteStatusOn
+    /// when SA1010110; is sent — simulating the real-world timing gap where the radio
+    /// needs settling time before it can confirm SATL.
+    /// </summary>
+    private sealed class NonConfirmingSatelliteTransport : IKenwoodCatTransport
+    {
+        private readonly bool _returnNull;
+
+        public NonConfirmingSatelliteTransport(bool returnNull)
+        {
+            _returnNull = returnNull;
+        }
+
+        public List<string> SentCommands { get; } = [];
+        public bool IsOpen { get; private set; }
+
+        public void Open() => IsOpen = true;
+
+        public bool SendFireAndForget(string command, int postDelayMs = 50)
+        {
+            SentCommands.Add(Normalize(command));
+            return true;
+        }
+
+        public bool SendCommand(string command, int postDelayMs = 50)
+        {
+            SentCommands.Add(Normalize(command));
+            return true;
+        }
+
+        public string? Transact(string command, int postDelayMs = 50)
+        {
+            var normalized = Normalize(command);
+            SentCommands.Add(normalized);
+
+            return normalized switch
+            {
+                // SA; query: radio does NOT confirm SATL (the bug condition)
+                "SA;" => _returnNull ? null : "SA0;",
+                // FA; read during handshake — return a valid frequency
+                "FA;" => "FA00435750000;",
+                _ => null
+            };
+        }
+
+        public void Dispose() => IsOpen = false;
+
+        private static string Normalize(string command)
+        {
+            var cmd = command.Trim();
+            return cmd.EndsWith(';') ? cmd : cmd + ";";
+        }
+    }
+}

--- a/OscarWatch.Tests/SatelliteModePreservationPropertyTests.cs
+++ b/OscarWatch.Tests/SatelliteModePreservationPropertyTests.cs
@@ -1,0 +1,338 @@
+// Feature: ts2000-satmode-entry-fix, Property 2: Preservation — Non-Entry-Path Behavior Unchanged
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Radio;
+using OscarWatch.Rig;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6**
+///
+/// Preservation property tests: verify that all non-entry-path behaviors remain unchanged.
+/// These tests MUST PASS on the unfixed code (they capture the baseline to protect).
+/// After the fix, these tests must still pass (confirming no regressions).
+/// </summary>
+public class SatelliteModePreservationPropertyTests
+{
+    // ────────────────────────────────────────────────────────────────────────────
+    // Property 2a: Exit sequence preservation
+    // Validates: Requirement 3.2
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// For any number of SetSatelliteMode(false) calls, the exit command sequence is always
+    /// exactly: RX;, TN39;, TO0;, TN39;, SA0010000; — unchanged.
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool Exit_sequence_is_always_RX_TN39_TO0_TN39_SA0010000(byte callCountByte)
+    {
+        var callCount = (callCountByte % 5) + 1; // 1-5 exit calls
+
+        var transport = new RecordingKenwoodCatTransport { SatelliteStatusOn = true };
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0);
+        driver.Open();
+
+        for (var i = 0; i < callCount; i++)
+        {
+            // Enter satellite mode first (so exit has something to do)
+            driver.SetSatelliteMode(true);
+            transport.SentCommands.Clear();
+
+            // Exit satellite mode
+            driver.SetSatelliteMode(false);
+
+            // Assert the exact exit sequence
+            string[] expectedExit = ["RX;", "TN39;", "TO0;", "TN39;", "SA0010000;"];
+            if (transport.SentCommands.Count != expectedExit.Length)
+                return false;
+
+            for (var j = 0; j < expectedExit.Length; j++)
+            {
+                if (transport.SentCommands[j] != expectedExit[j])
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Property 2b: Offline pre-configuration preservation
+    // Validates: Requirement 3.5
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// For any SetSatelliteMode(true) call with a closed transport, _satelliteMode is set
+    /// to true without sending any serial commands.
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool Offline_preconfig_sets_satellite_mode_without_serial_IO(bool initialState)
+    {
+        var transport = new RecordingKenwoodCatTransport();
+        // Do NOT open the transport — simulates offline pre-configuration
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0);
+
+        // Set initial state
+        if (initialState)
+        {
+            // Can't use SetSatelliteMode(true) on open transport here,
+            // so just set it via closed transport (which is exactly what we're testing)
+        }
+
+        transport.SentCommands.Clear();
+        driver.SetSatelliteMode(true);
+
+        // Assert: _satelliteMode is true
+        if (!driver.IsSatelliteModeActive)
+            return false;
+
+        // Assert: no commands were sent (transport was not open)
+        if (transport.SentCommands.Count != 0)
+            return false;
+
+        return true;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Property 2c: First-query success path preservation
+    // Validates: Requirement 3.1
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When SA; returns SA1; on the first query (radio confirms SATL immediately),
+    /// the driver sets _satelliteMode = true and sends tone/squelch clearing commands.
+    /// This is the happy path that must remain unchanged.
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool First_query_success_sets_mode_true_and_sends_tone_squelch_clearing(byte unusedSeed)
+    {
+        // RecordingKenwoodCatTransport with SatelliteStatusOn = true auto-confirms SA;
+        var transport = new RecordingKenwoodCatTransport { SatelliteStatusOn = true };
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0);
+        driver.Open();
+
+        driver.SetSatelliteMode(true);
+
+        // Assert: satellite mode is active
+        if (!driver.IsSatelliteModeActive)
+            return false;
+
+        // Assert: SA; query was sent and only once (no retries needed)
+        var saQueryCount = transport.SentCommands.Count(c => c == "SA;");
+        if (saQueryCount != 1)
+            return false;
+
+        // Assert: tone/squelch clearing was sent (TO0; commands after SA; confirmation)
+        // The SendSatelliteToneAndSquelchOff sends: SA1010110;, TO0;, DQ0;, CT0; (main path)
+        // then SA1011110;, TO0;, DQ0;, CT0; (sub path), then SA1010110; (final)
+        var saQueryIndex = transport.SentCommands.IndexOf("SA;");
+        var commandsAfterSa = transport.SentCommands.Skip(saQueryIndex + 1).ToList();
+
+        // Must contain TO0; (tone off) after SA; query
+        if (!commandsAfterSa.Contains("TO0;"))
+            return false;
+
+        // Must contain CT0; (CTCSS off) after SA; query
+        if (!commandsAfterSa.Contains("CT0;"))
+            return false;
+
+        // Must contain DQ0; after SA; query
+        if (!commandsAfterSa.Contains("DQ0;"))
+            return false;
+
+        return true;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Property 2d: ApplySatelliteDopplerStep preservation
+    // Validates: Requirements 3.3
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// For any valid downlink/uplink frequency pair, ApplySatelliteDopplerStep produces
+    /// the FA/FB/SM frequency cluster followed by 7 FA; link-hold polls.
+    /// The exact sequence pattern is: FA, FB, SM10000, FA, SM(sub), FB, SM(sub), SM10000,
+    /// then 7x FA; polls.
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool DopplerStep_produces_FA_FB_SM_cluster_and_link_hold_polls(
+        int downlinkSeed, int uplinkSeed)
+    {
+        // Generate valid frequencies in ham radio satellite bands
+        // Downlink: 144-148 MHz or 435-438 MHz
+        // Uplink: 144-148 MHz or 435-438 MHz
+        var downlinkHz = GenerateValidFrequency(downlinkSeed, isDownlink: true);
+        var uplinkHz = GenerateValidFrequency(uplinkSeed, isDownlink: false);
+
+        var transport = new RecordingKenwoodCatTransport { SatelliteStatusOn = true };
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0);
+        driver.Open();
+        driver.SetSatelliteMode(true);
+        transport.SentCommands.Clear();
+
+        var result = driver.ApplySatelliteDopplerStep(downlinkHz, uplinkHz);
+
+        if (!result)
+            return false;
+
+        var cmds = transport.SentCommands;
+
+        // Expected FA command for downlink
+        var expectedFa = $"FA{downlinkHz:D11};";
+        var expectedFb = $"FB{uplinkHz:D11};";
+
+        // The sequence should be: FA, FB, SM10000, FA, SM(sub), FB, SM(sub), SM10000, then 7x FA;
+        // Total = 8 cluster commands + 7 poll commands = 15
+        if (cmds.Count != 15)
+            return false;
+
+        // Verify cluster pattern
+        if (cmds[0] != expectedFa) return false;
+        if (cmds[1] != expectedFb) return false;
+        if (cmds[2] != "SM10000;") return false;
+        if (cmds[3] != expectedFa) return false;
+
+        // SM sub depends on frequency band: >= 200MHz => SM00004; else SM00021;
+        var expectedSmSub = downlinkHz >= 200_000_000 ? "SM00004;" : "SM00021;";
+        if (cmds[4] != expectedSmSub) return false;
+        if (cmds[5] != expectedFb) return false;
+        if (cmds[6] != expectedSmSub) return false;
+        if (cmds[7] != "SM10000;") return false;
+
+        // Verify 7 FA; link-hold polls
+        for (var i = 8; i < 15; i++)
+        {
+            if (cmds[i] != "FA;")
+                return false;
+        }
+
+        return true;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Property 2e: ApplySatellitePassFrequencies preservation
+    // Validates: Requirements 3.4
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// For any valid frequency and mode-code combination, ApplySatellitePassFrequencies
+    /// produces the double FA/FB, SM, mode, PC050, and tone sequence followed by
+    /// 7 FA; link-hold polls.
+    /// </summary>
+    [Property(MaxTest = 10)]
+    public bool PassFrequencies_produces_programming_sequence_and_link_hold_polls(
+        int downlinkSeed, int uplinkSeed, byte modeIndexByte)
+    {
+        var downlinkHz = GenerateValidFrequency(downlinkSeed, isDownlink: true);
+        var uplinkHz = GenerateValidFrequency(uplinkSeed, isDownlink: false);
+
+        // Valid TS-2000 mode codes: '1' (LSB), '2' (USB), '3' (CW), '4' (FM), '5' (AM)
+        char[] validModes = ['1', '2', '3', '4', '5'];
+        var downlinkModeCode = validModes[modeIndexByte % validModes.Length];
+        var uplinkModeCode = validModes[(modeIndexByte / 5) % validModes.Length];
+
+        var transport = new RecordingKenwoodCatTransport { SatelliteStatusOn = true };
+        var driver = new KenwoodTs2000Driver(transport, catDelayMs: 0);
+        driver.Open();
+        driver.SetSatelliteMode(true);
+        transport.SentCommands.Clear();
+
+        driver.ApplySatellitePassFrequencies(downlinkHz, uplinkHz, downlinkModeCode, uplinkModeCode);
+
+        var cmds = transport.SentCommands;
+
+        var expectedFa = $"FA{downlinkHz:D11};";
+        var expectedFb = $"FB{uplinkHz:D11};";
+        var expectedSmSub = downlinkHz >= 200_000_000 ? "SM00004;" : "SM00021;";
+
+        // Verify key commands are present in the sequence:
+        // 1. Double FA/FB (ProgramSatelliteFrequencies sends FA, FB, FA, FB)
+        var faCount = cmds.Count(c => c == expectedFa);
+        if (faCount < 2) return false;
+
+        var fbCount = cmds.Count(c => c == expectedFb);
+        if (fbCount < 2) return false;
+
+        // 2. SM band select commands present
+        if (!cmds.Contains("SM10000;")) return false;
+        if (!cmds.Contains(expectedSmSub)) return false;
+
+        // 3. Mode commands (MD) for downlink and uplink
+        var expectedDownlinkMode = $"MD{downlinkModeCode};";
+        var expectedUplinkMode = $"MD{uplinkModeCode};";
+        if (!cmds.Contains(expectedDownlinkMode)) return false;
+        if (!cmds.Contains(expectedUplinkMode)) return false;
+
+        // 4. PC050; power level command
+        if (!cmds.Contains("PC050;")) return false;
+
+        // 5. SA1010110; and SA1011110; control commands (satellite mode on / sub control)
+        if (!cmds.Contains("SA1010110;")) return false;
+        if (!cmds.Contains("SA1011110;")) return false;
+
+        // 6. TO0; tone off commands
+        if (!cmds.Contains("TO0;")) return false;
+
+        // 7. AI0; autoinfo off at the end
+        if (!cmds.Contains("AI0;")) return false;
+
+        // 8. 7 FA; link-hold polls at the end
+        var linkHoldPolls = cmds.Count(c => c == "FA;");
+        if (linkHoldPolls != 7) return false;
+
+        // 9. The link-hold polls must be at the end
+        var lastNonPollIndex = -1;
+        for (var i = cmds.Count - 1; i >= 0; i--)
+        {
+            if (cmds[i] != "FA;")
+            {
+                lastNonPollIndex = i;
+                break;
+            }
+        }
+
+        // All commands after lastNonPollIndex should be FA;
+        for (var i = lastNonPollIndex + 1; i < cmds.Count; i++)
+        {
+            if (cmds[i] != "FA;") return false;
+        }
+
+        // And there should be exactly 7 of them
+        if (cmds.Count - lastNonPollIndex - 1 != 7) return false;
+
+        return true;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Generates a valid amateur satellite frequency from a seed integer.
+    /// Constrains to realistic VHF/UHF ham bands used for satellite work.
+    /// </summary>
+    private static long GenerateValidFrequency(int seed, bool isDownlink)
+    {
+        // Use absolute value and modulo to constrain to valid ranges
+        var absSeed = Math.Abs((long)seed);
+
+        if (isDownlink)
+        {
+            // Downlink bands: 145.800-146.000 MHz (2m) or 435.000-438.000 MHz (70cm)
+            if (absSeed % 2 == 0)
+                return 145_800_000 + (absSeed % 200_000); // 145.800-146.000 MHz
+            else
+                return 435_000_000 + (absSeed % 3_000_000); // 435.000-438.000 MHz
+        }
+        else
+        {
+            // Uplink bands: 145.900-146.000 MHz (2m) or 435.000-438.000 MHz (70cm)
+            if (absSeed % 2 == 0)
+                return 145_900_000 + (absSeed % 100_000); // 145.900-146.000 MHz
+            else
+                return 435_000_000 + (absSeed % 3_000_000); // 435.000-438.000 MHz
+        }
+    }
+}

--- a/OscarWatch/Rig/KenwoodTs2000Driver.cs
+++ b/OscarWatch/Rig/KenwoodTs2000Driver.cs
@@ -14,6 +14,9 @@ public sealed class KenwoodTs2000Driver : IRigDriver
 
     private readonly IKenwoodCatTransport _transport;
     private readonly int _catDelayMs;
+    private readonly int _satModeSettlingDelayMs;
+    private readonly int _satModeRetryCount;
+    private readonly int _satModeRetryDelayMs;
     private bool _satelliteMode;
     private bool _satelliteLayoutConfirmed;
     private RigVfo _currentVfo = RigVfo.Main;
@@ -22,15 +25,18 @@ public sealed class KenwoodTs2000Driver : IRigDriver
     private long _lastVfoAHz;
     private long _lastVfoBHz;
 
-    public KenwoodTs2000Driver(string port, int baudRate, int catDelayMs = 50)
-        : this(new KenwoodCatTransport(port, baudRate), catDelayMs)
+    public KenwoodTs2000Driver(string port, int baudRate, int catDelayMs = 50, int satModeSettlingDelayMs = 250, int satModeRetryCount = 3, int satModeRetryDelayMs = 200)
+        : this(new KenwoodCatTransport(port, baudRate), catDelayMs, satModeSettlingDelayMs, satModeRetryCount, satModeRetryDelayMs)
     {
     }
 
-    internal KenwoodTs2000Driver(IKenwoodCatTransport transport, int catDelayMs = 50)
+    internal KenwoodTs2000Driver(IKenwoodCatTransport transport, int catDelayMs = 50, int satModeSettlingDelayMs = 250, int satModeRetryCount = 3, int satModeRetryDelayMs = 200)
     {
         _transport = transport;
         _catDelayMs = catDelayMs;
+        _satModeSettlingDelayMs = satModeSettlingDelayMs;
+        _satModeRetryCount = satModeRetryCount;
+        _satModeRetryDelayMs = satModeRetryDelayMs;
     }
 
     public RigType RigType => RigType.KenwoodTs2000;
@@ -208,13 +214,14 @@ public sealed class KenwoodTs2000Driver : IRigDriver
 
         if (on)
         {
-            _satelliteMode = TryEnableSatelliteMode();
-            _satelliteLayoutConfirmed = _satelliteMode;
-            if (!_satelliteLayoutConfirmed)
+            var result = TryEnableSatelliteMode();
+            _satelliteMode = result;
+            _satelliteLayoutConfirmed = result;
+            if (!result)
             {
-                Log.Warning(
-                    "TS-2000 SATL not confirmed via SA; — continuing FA/FB tracking. Check SAT on front panel and memory mode off.");
-                _satelliteMode = true;
+                Log.Error(
+                    "TS-2000 SATL not confirmed after {RetryCount} SA; verification attempts. Radio may not be in satellite mode.",
+                    _satModeRetryCount);
             }
 
             return;
@@ -361,16 +368,30 @@ public sealed class KenwoodTs2000Driver : IRigDriver
     private bool TryEnableSatelliteMode()
     {
         _transport.SendFireAndForget(KenwoodCatCodec.BuildSetSatelliteModeOnCommand(), _catDelayMs);
+
+        // Settling delay: give the radio time to transition its internal state to SATL
+        // before proceeding with the entry handshake and verification query.
+        if (_satModeSettlingDelayMs > 0)
+            Thread.Sleep(_satModeSettlingDelayMs);
+
         foreach (var toneOff in KenwoodCatCodec.SatelliteModeEntryToneOffSequence)
             _transport.SendFireAndForget(toneOff, _catDelayMs);
 
         SendSatelliteEntryHandshake();
 
-        var reply = _transport.Transact(KenwoodCatCodec.BuildSatelliteStatusQuery(), _catDelayMs);
-        if (reply is not null && KenwoodCatCodec.TryParseSatelliteOn(reply))
+        // Retry loop: attempt SA; verification up to _satModeRetryCount times
+        // with inter-attempt delays, accounting for variable radio processing time.
+        for (var attempt = 1; attempt <= _satModeRetryCount; attempt++)
         {
-            SendSatelliteToneAndSquelchOff();
-            return true;
+            var reply = _transport.Transact(KenwoodCatCodec.BuildSatelliteStatusQuery(), _catDelayMs);
+            if (reply is not null && KenwoodCatCodec.TryParseSatelliteOn(reply))
+            {
+                SendSatelliteToneAndSquelchOff();
+                return true;
+            }
+
+            if (attempt < _satModeRetryCount && _satModeRetryDelayMs > 0)
+                Thread.Sleep(_satModeRetryDelayMs);
         }
 
         return false;


### PR DESCRIPTION
Fixes silent satellite mode entry failure on the Kenwood TS-2000. The radio never actually enters SATL because the driver queried SA; too soon after SA1010110; and then overrode the failure.

## Changes

- Add 250ms settling delay after SA1010110; before entry handshake
- Add SA; verification retry loop (3 attempts, 200ms between)
- Remove resilience override that masked verification failure
- IsSatelliteModeActive now accurately reflects radio state
- Configurable retry/delay params for testability