### PR TITLE
Eliminate hot path allocations in rig, database, and state lookup

### DIFF
--- a/OscarWatch.Core/Services/IRigController.cs
+++ b/OscarWatch.Core/Services/IRigController.cs
@@ -8,7 +8,8 @@ public interface IRigController
 
     /// <summary>Enqueue latest pass/settings for the dedicated rig thread (~1–4 Hz from UI).</summary>
     /// <param name="reinitializePass">When true and the pass key is unchanged, re-run SAT mode / frequency setup (e.g. user re-selected a satellite). When false, offset-only updates force an immediate doppler write.</param>
-    void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false);
+    /// <param name="catPausedOverride">When non-null, overrides <see cref="RigSettings.CatUpdatesPaused"/> without cloning the settings object.</param>
+    void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false, bool? catPausedOverride = null);
 
     /// <summary>Synchronous publish + doppler tick on the rig thread (unit tests).</summary>
     void Update(RigSettings settings, RigTrackingContext? context);

--- a/OscarWatch.Core/Services/SatelliteDatabaseService.cs
+++ b/OscarWatch.Core/Services/SatelliteDatabaseService.cs
@@ -12,6 +12,9 @@ public sealed class SatelliteDatabaseService : ISatelliteDatabaseService
     private Dictionary<string, SatelliteRadioEntry> _byName =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private Dictionary<string, SatelliteRadioEntry> _byNormalizedName =
+        new(StringComparer.Ordinal);
+
     private List<SatelliteRadioEntry> _entries = [];
 
     public IReadOnlyList<SatelliteRadioEntry> Entries => _entries;
@@ -54,6 +57,10 @@ public sealed class SatelliteDatabaseService : ISatelliteDatabaseService
             _byName[entry.Name.Trim()] = entry;
             RegisterParentheticalAlias(entry.Name.Trim());
         }
+
+        _byNormalizedName = new Dictionary<string, SatelliteRadioEntry>(_byName.Count, StringComparer.Ordinal);
+        foreach (var (key, entry) in _byName)
+            _byNormalizedName.TryAdd(NormalizeName(key), entry);
     }
 
     public SatelliteRadioEntry? TryGetEntry(string satelliteName)
@@ -96,13 +103,7 @@ public sealed class SatelliteDatabaseService : ISatelliteDatabaseService
         }
 
         var normalized = NormalizeName(trimmed);
-        foreach (var key in _byName.Keys)
-        {
-            if (NormalizeName(key) == normalized)
-                return _byName[key];
-        }
-
-        return null;
+        return _byNormalizedName.GetValueOrDefault(normalized);
     }
 
     private static string NormalizeName(string name) =>

--- a/OscarWatch.Tests/CatPausedOverridePropertyTests.cs
+++ b/OscarWatch.Tests/CatPausedOverridePropertyTests.cs
@@ -1,0 +1,69 @@
+// Feature: performance-optimisations, Property 5: CatUpdatesPaused override equivalence
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 5.1, 5.2, 5.3**
+///
+/// Property-based tests verifying that the catPausedOverride mechanism produces the same
+/// effective CatUpdatesPaused value as the formula: catPausedOverride ?? settings.CatUpdatesPaused.
+/// This matches the behaviour the previous deep-clone approach would have produced.
+/// </summary>
+public class CatPausedOverridePropertyTests
+{
+    /// <summary>
+    /// Computes the effective CatUpdatesPaused value using the same logic as RigController.ApplyPublishState:
+    /// <c>var effectivePaused = catPausedOverride ?? settings.CatUpdatesPaused;</c>
+    /// </summary>
+    private static bool ComputeEffectivePaused(bool settingsCatUpdatesPaused, bool? catPausedOverride)
+        => catPausedOverride ?? settingsCatUpdatesPaused;
+
+    /// <summary>
+    /// Property 5: CatUpdatesPaused override equivalence.
+    ///
+    /// For any RigSettings.CatUpdatesPaused value and any catPausedOverride (null, true, or false),
+    /// the effective paused value SHALL equal catPausedOverride ?? settings.CatUpdatesPaused.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Effective_paused_equals_override_coalesce_settings(bool settingsPaused, bool? overrideValue)
+    {
+        var settings = new RigSettings { CatUpdatesPaused = settingsPaused };
+
+        var effective = ComputeEffectivePaused(settings.CatUpdatesPaused, overrideValue);
+        var expected = overrideValue ?? settings.CatUpdatesPaused;
+
+        return effective == expected;
+    }
+
+    /// <summary>
+    /// Property 5: When catPausedOverride is null, effective value equals settings.CatUpdatesPaused.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Null_override_returns_settings_value(bool settingsPaused)
+    {
+        var settings = new RigSettings { CatUpdatesPaused = settingsPaused };
+
+        var effective = ComputeEffectivePaused(settings.CatUpdatesPaused, null);
+
+        return effective == settingsPaused;
+    }
+
+    /// <summary>
+    /// Property 5: When catPausedOverride is non-null, effective value equals the override
+    /// regardless of settings.CatUpdatesPaused.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool NonNull_override_takes_precedence(bool settingsPaused, bool overrideBool)
+    {
+        var settings = new RigSettings { CatUpdatesPaused = settingsPaused };
+        bool? overrideValue = overrideBool;
+
+        var effective = ComputeEffectivePaused(settings.CatUpdatesPaused, overrideValue);
+
+        return effective == overrideBool;
+    }
+}

--- a/OscarWatch.Tests/DiagnosticsBundleBuilderTests.cs
+++ b/OscarWatch.Tests/DiagnosticsBundleBuilderTests.cs
@@ -102,7 +102,7 @@ public sealed class DiagnosticsBundleBuilderTests
     private sealed class StubRigController(RigConnectionStatus status) : IRigController
     {
         public RigConnectionStatus GetStatus() => status;
-        public void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false) { }
+        public void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false, bool? catPausedOverride = null) { }
         public void Update(RigSettings settings, RigTrackingContext? context) { }
         public void ApplySelectedCtcss(RigSettings settings, RigTrackingContext? context) { }
         public void Disconnect() { }

--- a/OscarWatch.Tests/GetFocusedTrackStatePropertyTests.cs
+++ b/OscarWatch.Tests/GetFocusedTrackStatePropertyTests.cs
@@ -1,0 +1,99 @@
+// Feature: performance-optimisations, Property 7: GetFocusedTrackState for-loop equivalence
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 7.1, 7.2**
+///
+/// Property-based tests verifying that the for-loop implementation of GetFocusedTrackState
+/// returns the same result as the LINQ FirstOrDefault reference for all inputs.
+/// </summary>
+public class GetFocusedTrackStatePropertyTests
+{
+    /// <summary>
+    /// Reference implementation using LINQ FirstOrDefault (the original code path).
+    /// </summary>
+    private static SatelliteTrackState? ReferenceGetFocusedTrackState(
+        IReadOnlyList<SatelliteTrackState> states, string? focusedNoradId)
+    {
+        if (string.IsNullOrEmpty(focusedNoradId))
+            return null;
+
+        return states.FirstOrDefault(s => string.Equals(s.NoradId, focusedNoradId, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// For-loop implementation (replicates the private static method in MainViewModel).
+    /// </summary>
+    private static SatelliteTrackState? ForLoopGetFocusedTrackState(
+        IReadOnlyList<SatelliteTrackState> states, string? focusedNoradId)
+    {
+        if (string.IsNullOrEmpty(focusedNoradId))
+            return null;
+
+        for (var i = 0; i < states.Count; i++)
+        {
+            if (string.Equals(states[i].NoradId, focusedNoradId, StringComparison.Ordinal))
+                return states[i];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Create a minimal SatelliteTrackState with a given NoradId.
+    /// </summary>
+    private static SatelliteTrackState MakeState(string noradId) => new()
+    {
+        Name = noradId,
+        NoradId = noradId,
+        Subpoint = new GeoCoordinate(0, 0, 400)
+    };
+
+    /// <summary>
+    /// Property 7: GetFocusedTrackState for-loop equivalence.
+    ///
+    /// For any list of 0–50 SatelliteTrackState entries and any focusedNoradId
+    /// (including null, empty, present in the list, and absent from the list),
+    /// the for-loop implementation SHALL return the same result as FirstOrDefault LINQ reference.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool ForLoop_matches_FirstOrDefault_reference(byte stateCountByte, byte[] noradIdSeeds, byte focusedStrategy)
+    {
+        // Map state count to 0–50 range
+        var stateCount = stateCountByte % 51;
+
+        // Build states with NoradIds (allowing duplicates to exercise first-match semantics)
+        var states = new List<SatelliteTrackState>(stateCount);
+        for (var i = 0; i < stateCount; i++)
+        {
+            var seed = (noradIdSeeds is not null && i < noradIdSeeds.Length)
+                ? noradIdSeeds[i]
+                : (byte)i;
+            var noradId = $"{seed:D3}{i % 10:D1}";
+            states.Add(MakeState(noradId));
+        }
+
+        // Determine focused NORAD ID based on strategy (covers null, empty, present, absent)
+        var strategy = focusedStrategy % 5;
+        string? focusedNoradId = strategy switch
+        {
+            0 => null,                                                              // null
+            1 => "",                                                                // empty
+            2 when states.Count > 0 => states[focusedStrategy % states.Count].NoradId, // present in list
+            3 => "ABSENT_ID_99999",                                                 // absent from list
+            _ => "ABSENT_ID_88888"                                                  // also absent (covers strategy 2 with empty list and strategy 4)
+        };
+
+        // Execute both implementations
+        var expected = ReferenceGetFocusedTrackState(states, focusedNoradId);
+        var actual = ForLoopGetFocusedTrackState(states, focusedNoradId);
+
+        // Both should return the same result (same reference or both null)
+        return ReferenceEquals(expected, actual);
+    }
+}

--- a/OscarWatch.Tests/NormalisedNameResolutionPropertyTests.cs
+++ b/OscarWatch.Tests/NormalisedNameResolutionPropertyTests.cs
@@ -1,0 +1,198 @@
+// Feature: performance-optimisations, Property 6: Normalised name resolution equivalence
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 6.1, 6.2, 6.3**
+///
+/// Property-based tests verifying that the O(1) normalised-name dictionary lookup
+/// returns the same result as an O(n) foreach scan over all keys with NormalizeName comparison.
+/// </summary>
+public class NormalisedNameResolutionPropertyTests
+{
+    /// <summary>
+    /// Replicates the NormalizeName logic from SatelliteDatabaseService (private static).
+    /// </summary>
+    private static string NormalizeName(string name) =>
+        name.Replace(" ", "", StringComparison.Ordinal)
+            .Replace("-", "", StringComparison.Ordinal)
+            .ToUpperInvariant();
+
+    /// <summary>
+    /// O(n) reference implementation: iterate all keys in order, normalize each,
+    /// and return the first entry whose normalized key matches the normalized query.
+    /// </summary>
+    private static string? LinearScanResolve(
+        IReadOnlyList<KeyValuePair<string, string>> entries,
+        string query)
+    {
+        var normalizedQuery = NormalizeName(query);
+        foreach (var (key, value) in entries)
+        {
+            if (string.Equals(NormalizeName(key), normalizedQuery, StringComparison.Ordinal))
+                return value;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// O(1) dictionary implementation: build a dictionary using TryAdd (first-wins),
+    /// then perform a single lookup.
+    /// </summary>
+    private static string? DictionaryResolve(
+        IReadOnlyList<KeyValuePair<string, string>> entries,
+        string query)
+    {
+        var dict = new Dictionary<string, string>(entries.Count, StringComparer.Ordinal);
+        foreach (var (key, value) in entries)
+            dict.TryAdd(NormalizeName(key), value);
+
+        return dict.GetValueOrDefault(NormalizeName(query));
+    }
+
+    /// <summary>
+    /// Generates a satellite name with spaces, hyphens, and mixed case.
+    /// Uses byte seeds to build deterministic but varied names.
+    /// </summary>
+    private static string GenerateSatelliteName(byte[] seeds, int index)
+    {
+        var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        var separators = new[] { ' ', '-', ' ', '-' };
+        var seed = (seeds is not null && index < seeds.Length) ? seeds[index] : (byte)(index * 7);
+
+        var length = (seed % 12) + 3; // 3–14 chars
+        var result = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            var charSeed = (byte)((seed + i * 13) % 256);
+            var choice = charSeed % 30;
+            if (choice < 26)
+            {
+                var c = chars[choice];
+                // Mix case based on position and seed
+                result[i] = (charSeed % 3 == 0) ? char.ToLowerInvariant(c) : c;
+            }
+            else
+            {
+                // Insert separator (space or hyphen)
+                result[i] = separators[choice % separators.Length];
+            }
+        }
+
+        return new string(result);
+    }
+
+    /// <summary>
+    /// Property 6: Normalised name resolution equivalence.
+    ///
+    /// For any set of satellite names (containing spaces, hyphens, mixed case)
+    /// and any query string, the O(1) dictionary lookup returns the same result
+    /// as the O(n) foreach loop reference.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Dictionary_lookup_matches_linear_scan(
+        byte entryCountByte,
+        byte[] nameSeeds,
+        byte querySeed)
+    {
+        // Generate 5–50 entries
+        var entryCount = (entryCountByte % 46) + 5;
+        var entries = new List<KeyValuePair<string, string>>(entryCount);
+
+        for (var i = 0; i < entryCount; i++)
+        {
+            var name = GenerateSatelliteName(nameSeeds, i);
+            var value = $"Entry_{i}";
+            entries.Add(new KeyValuePair<string, string>(name, value));
+        }
+
+        // Generate a query string — sometimes pick from existing names (to test hits),
+        // sometimes generate a new one (to test misses)
+        string query;
+        var strategy = querySeed % 4;
+        if (strategy < 2 && entries.Count > 0)
+        {
+            // Use an existing name (potentially with case/separator variations)
+            var sourceEntry = entries[querySeed % entries.Count].Key;
+            query = strategy == 0
+                ? sourceEntry                          // exact match
+                : sourceEntry.ToLowerInvariant();       // case variation
+        }
+        else
+        {
+            // Generate a random query (likely a miss)
+            query = GenerateSatelliteName(
+                nameSeeds is not null && nameSeeds.Length > 0
+                    ? [(byte)(nameSeeds[0] ^ querySeed)]
+                    : [querySeed],
+                querySeed);
+        }
+
+        var linearResult = LinearScanResolve(entries, query);
+        var dictResult = DictionaryResolve(entries, query);
+
+        return linearResult == dictResult;
+    }
+
+    /// <summary>
+    /// Property 6: First-wins semantics preserved on collisions.
+    ///
+    /// When multiple entries normalize to the same key, both the dictionary and
+    /// the linear scan return the same (first) entry.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool First_wins_on_normalized_collisions(byte baseSeed)
+    {
+        // Deliberately create entries that collide after normalization
+        // e.g., "AO-7", "AO 7", "ao-7" all normalize to "AO7"
+        var baseName = GenerateSatelliteName([baseSeed], 0);
+        var entries = new List<KeyValuePair<string, string>>
+        {
+            new(baseName, "First"),
+            new(baseName.Replace(" ", "-"), "Second"),
+            new(baseName.ToLowerInvariant(), "Third"),
+            new(baseName.ToUpperInvariant().Replace("-", " "), "Fourth")
+        };
+
+        var query = baseName;
+
+        var linearResult = LinearScanResolve(entries, query);
+        var dictResult = DictionaryResolve(entries, query);
+
+        return linearResult == dictResult;
+    }
+
+    /// <summary>
+    /// Property 6: Empty or whitespace-only queries resolve consistently.
+    /// Both approaches should find no match or the same match.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Empty_and_whitespace_queries_resolve_consistently(byte entryCountByte, byte[] nameSeeds)
+    {
+        var entryCount = (entryCountByte % 20) + 1;
+        var entries = new List<KeyValuePair<string, string>>(entryCount);
+
+        for (var i = 0; i < entryCount; i++)
+        {
+            var name = GenerateSatelliteName(nameSeeds, i);
+            entries.Add(new KeyValuePair<string, string>(name, $"Entry_{i}"));
+        }
+
+        // Test with various "empty-ish" queries
+        var queries = new[] { "", " ", "-", "- -", "  --  " };
+
+        foreach (var query in queries)
+        {
+            var linearResult = LinearScanResolve(entries, query);
+            var dictResult = DictionaryResolve(entries, query);
+            if (linearResult != dictResult)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/OscarWatch/Rig/RigController.cs
+++ b/OscarWatch/Rig/RigController.cs
@@ -79,6 +79,7 @@ public sealed class RigController : IRigController, IDisposable
 
     private RigSettings _cachedSettings = new();
     private RigTrackingContext? _cachedContext;
+    private bool? _cachedCatPausedOverride;
     private RigConnectionStatus _status = new(false, false, RigStatusKind.None, null, null, null, null, false, 0, 0);
 
     public RigController(
@@ -96,8 +97,8 @@ public sealed class RigController : IRigController, IDisposable
     }
 
     /// <summary>Enqueue latest pass/settings for the rig thread (~1–4 Hz from UI).</summary>
-    public void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false) =>
-        Enqueue(new RigCommand(RigCommandKind.PublishContext, settings, context, reinitializePass));
+    public void PublishContext(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false, bool? catPausedOverride = null) =>
+        Enqueue(new RigCommand(RigCommandKind.PublishContext, settings, context, reinitializePass, catPausedOverride));
 
     /// <summary>Runs one doppler iteration on the rig thread (unit tests).</summary>
     public void RunTrackingLoopOnce() =>
@@ -217,7 +218,8 @@ public sealed class RigController : IRigController, IDisposable
                 case RigCommandKind.PublishContext:
                     _cachedSettings = command.Settings;
                     _cachedContext = command.Context;
-                    ApplyPublishState(_cachedSettings, _cachedContext, command.ReinitializePass);
+                    _cachedCatPausedOverride = command.CatPausedOverride;
+                    ApplyPublishState(_cachedSettings, _cachedContext, command.ReinitializePass, command.CatPausedOverride);
                     if (!command.ReinitializePass && _forceFrequencyApply)
                         RunLoopIteration(ignoreDopplerSuspend: true);
                     break;
@@ -225,7 +227,8 @@ public sealed class RigController : IRigController, IDisposable
                 case RigCommandKind.UpdateSynchronously:
                     _cachedSettings = command.Settings;
                     _cachedContext = command.Context;
-                    ApplyPublishState(_cachedSettings, _cachedContext);
+                    _cachedCatPausedOverride = command.CatPausedOverride;
+                    ApplyPublishState(_cachedSettings, _cachedContext, catPausedOverride: command.CatPausedOverride);
                     RunLoopIteration(ignoreDopplerSuspend: true);
                     break;
 
@@ -297,7 +300,7 @@ public sealed class RigController : IRigController, IDisposable
             _status = snapshot;
     }
 
-    private void ApplyPublishState(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false)
+    private void ApplyPublishState(RigSettings settings, RigTrackingContext? context, bool reinitializePass = false, bool? catPausedOverride = null)
     {
         if (!RigIsConfigured(settings))
         {
@@ -321,8 +324,9 @@ public sealed class RigController : IRigController, IDisposable
             return;
         }
 
-        var resumingFromCatPause = _catUpdatesPaused && !settings.CatUpdatesPaused;
-        _catUpdatesPaused = settings.CatUpdatesPaused;
+        var effectivePaused = catPausedOverride ?? settings.CatUpdatesPaused;
+        var resumingFromCatPause = _catUpdatesPaused && !effectivePaused;
+        _catUpdatesPaused = effectivePaused;
 
         if (context is not null)
             SyncDisplayFrequencies(context);
@@ -330,7 +334,7 @@ public sealed class RigController : IRigController, IDisposable
         if (context is null || context.TrackState.LookAngles is null)
         {
             _isTracking = false;
-            SetRigStatus(settings.CatUpdatesPaused ? RigStatusKind.CatPaused : RigStatusKind.Connected);
+            SetRigStatus(effectivePaused ? RigStatusKind.CatPaused : RigStatusKind.Connected);
             return;
         }
 
@@ -342,9 +346,9 @@ public sealed class RigController : IRigController, IDisposable
         var newPassKey = PassKey(context);
         var passKeyChanged = !string.Equals(_passKey, newPassKey, StringComparison.Ordinal);
         if (passKeyChanged)
-            BeginNewPass(settings, context, newPassKey);
+            BeginNewPass(settings, context, newPassKey, effectivePaused);
 
-        if (settings.CatUpdatesPaused)
+        if (effectivePaused)
         {
             _isTracking = false;
             SetRigStatus(RigStatusKind.CatPaused);
@@ -377,7 +381,7 @@ public sealed class RigController : IRigController, IDisposable
     private void SetRigStatus((RigStatusKind Kind, string? Port, string? Detail) status) =>
         SetRigStatus(status.Kind, status.Port, status.Detail);
 
-    private void BeginNewPass(RigSettings settings, RigTrackingContext context, string newPassKey)
+    private void BeginNewPass(RigSettings settings, RigTrackingContext context, string newPassKey, bool effectivePaused)
     {
         _passKey = newPassKey;
         _passbandDownlinkAdjustKHz = 0;
@@ -389,7 +393,7 @@ public sealed class RigController : IRigController, IDisposable
         _lastContextDopplerStrategy = context.DopplerStrategy;
         _forceFrequencyApply = false;
 
-        if (settings.CatUpdatesPaused)
+        if (effectivePaused)
             _passInitPending = true;
         else
             RunPassInit(settings, context);
@@ -420,6 +424,7 @@ public sealed class RigController : IRigController, IDisposable
         ClearDialHistory();
         _passInitPending = false;
         _catUpdatesPaused = false;
+        _cachedCatPausedOverride = null;
         _lastAppliedCtcssHz = null;
         _lastAppliedCtcssSquelch = null;
         _lastPassDownlinkOnVhf = null;
@@ -432,7 +437,7 @@ public sealed class RigController : IRigController, IDisposable
         if (!IsRigConnected() || _cachedContext is null)
             return;
 
-        if (!_cachedSettings.Enabled || _cachedSettings.CatUpdatesPaused || !_isTracking)
+        if (!_cachedSettings.Enabled || (_cachedCatPausedOverride ?? _cachedSettings.CatUpdatesPaused) || !_isTracking)
             return;
 
         if (!ignoreDopplerSuspend && DateTime.UtcNow < _suspendDopplerUntilUtc)
@@ -1551,18 +1556,21 @@ public sealed class RigController : IRigController, IDisposable
             RigCommandKind kind,
             RigSettings? settings = null,
             RigTrackingContext? context = null,
-            bool reinitializePass = false)
+            bool reinitializePass = false,
+            bool? catPausedOverride = null)
         {
             Kind = kind;
             Settings = settings ?? new RigSettings();
             Context = context;
             ReinitializePass = reinitializePass;
+            CatPausedOverride = catPausedOverride;
         }
 
         public RigCommandKind Kind { get; }
         public RigSettings Settings { get; }
         public RigTrackingContext? Context { get; }
         public bool ReinitializePass { get; }
+        public bool? CatPausedOverride { get; }
         public ManualResetEventSlim? Completed { get; set; }
     }
 }

--- a/OscarWatch/ViewModels/MainViewModel.cs
+++ b/OscarWatch/ViewModels/MainViewModel.cs
@@ -326,7 +326,7 @@ public partial class MainViewModel : ViewModelBase
         var context = Frequencies.TryBuildRigTrackingContext(focused);
         var rigSettings = GetRigSettingsForController();
         _rig.ApplySelectedCtcss(rigSettings, context);
-        _rig.PublishContext(rigSettings, context);
+        _rig.PublishContext(rigSettings, context, catPausedOverride: GetCatPausedOverride());
         RefreshRigUi(focused);
     }
 
@@ -337,7 +337,7 @@ public partial class MainViewModel : ViewModelBase
 
         var focused = GetFocusedTrackState(_liveTracking.GetSnapshot(), FocusedNoradId);
         var context = Frequencies.TryBuildRigTrackingContext(focused);
-        _rig.PublishContext(GetRigSettingsForController(), context, reinitializePass);
+        _rig.PublishContext(GetRigSettingsForController(), context, reinitializePass, catPausedOverride: GetCatPausedOverride());
         RefreshRigUi(focused);
     }
 
@@ -631,42 +631,16 @@ public partial class MainViewModel : ViewModelBase
             return;
 
         focused ??= GetFocusedTrackState(_liveTracking.GetSnapshot(), FocusedNoradId);
-        _rig.PublishContext(GetRigSettingsForController(), Frequencies.TryBuildRigTrackingContext(focused));
+        _rig.PublishContext(GetRigSettingsForController(), Frequencies.TryBuildRigTrackingContext(focused), catPausedOverride: GetCatPausedOverride());
     }
 
-    private RigSettings GetRigSettingsForController()
+    private RigSettings GetRigSettingsForController() => _settings.Current.Rig;
+
+    private bool? GetCatPausedOverride()
     {
         var rig = _settings.Current.Rig;
-        if (rig.CatUpdatesPaused == RigCatPaused)
-            return rig;
-
-        return new RigSettings
-        {
-            Enabled = rig.Enabled,
-            DualRadioEnabled = rig.DualRadioEnabled,
-            Downlink = CloneEndpoint(rig.Downlink),
-            Uplink = CloneEndpoint(rig.Uplink),
-            Type = rig.Type,
-            Port = rig.Port,
-            BaudRate = rig.BaudRate,
-            CivAddress = rig.CivAddress,
-            Region = rig.Region,
-            DopplerThresholdFmHz = rig.DopplerThresholdFmHz,
-            DopplerThresholdLinearHz = rig.DopplerThresholdLinearHz,
-            CatDelayMs = rig.CatDelayMs,
-            CatUpdatesPaused = RigCatPaused,
-            CwKeepSidebandDownlink = rig.CwKeepSidebandDownlink
-        };
+        return RigCatPaused != rig.CatUpdatesPaused ? RigCatPaused : null;
     }
-
-    private static RigEndpointSettings CloneEndpoint(RigEndpointSettings endpoint) => new()
-    {
-        Type = endpoint.Type,
-        Port = endpoint.Port,
-        BaudRate = endpoint.BaudRate,
-        Region = endpoint.Region,
-        CatDelayMs = endpoint.CatDelayMs
-    };
 
     private void PushCloudlogRadio(SatelliteTrackState? focused)
     {
@@ -1051,7 +1025,13 @@ public partial class MainViewModel : ViewModelBase
         if (string.IsNullOrEmpty(focusedNoradId))
             return null;
 
-        return states.FirstOrDefault(s => string.Equals(s.NoradId, focusedNoradId, StringComparison.Ordinal));
+        for (var i = 0; i < states.Count; i++)
+        {
+            if (string.Equals(states[i].NoradId, focusedNoradId, StringComparison.Ordinal))
+                return states[i];
+        }
+
+        return null;
     }
 
     private void ProcessVoiceAnnouncements(IReadOnlyList<SatelliteTrackState> states)


### PR DESCRIPTION
Summary
Removes per-tick heap allocations from three service-layer hot paths: the RigSettings deep-clone at 4 Hz, the O(n) normalised-name scan in satellite database resolution, and the LINQ enumerator allocation in focused-state lookup at ~10 Hz.

Changes
RigSettings clone removal:

MainViewModel.GetRigSettingsForController() now returns _settings.Current.Rig directly — no allocation
Added bool? catPausedOverride parameter to IRigController.PublishContext and RigController
RigController.ApplyPublishState computes effectivePaused = catPausedOverride ?? settings.CatUpdatesPaused
Removed CloneEndpoint helper (no longer needed)
Normalised-name O(1) dictionary:

SatelliteDatabaseService.Reload() now builds a _byNormalizedName dictionary with TryAdd (first-wins)
ResolveEntry normalised-name fallback changed from foreach + NormalizeName per key → single _byNormalizedName.GetValueOrDefault(normalized) call
GetFocusedTrackState for-loop:

Replaced states.FirstOrDefault(s => ...) with an explicit for loop — no IEnumerator<T> allocation