### PR TITLE
cache MotionHeadingDeg with 8s freshness window

### DIFF
--- a/OscarWatch.Core/Services/SatelliteVisualCache.cs
+++ b/OscarWatch.Core/Services/SatelliteVisualCache.cs
@@ -9,6 +9,7 @@ internal sealed class SatelliteVisualCache
 {
     private static readonly TimeSpan GroundTrackRefreshInterval = TimeSpan.FromSeconds(45);
     private static readonly TimeSpan FootprintRefreshInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MotionHeadingRefreshInterval = TimeSpan.FromSeconds(8);
 
     private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
 
@@ -47,6 +48,19 @@ internal sealed class SatelliteVisualCache
         return footprint.Count >= 3;
     }
 
+    public bool TryGetFreshMotionHeading(string noradId, DateTime utc, out double? headingDeg)
+    {
+        headingDeg = null;
+        if (!_entries.TryGetValue(noradId, out var entry))
+            return false;
+
+        if (IsStale(utc, entry.MotionHeadingUtc, MotionHeadingRefreshInterval))
+            return false;
+
+        headingDeg = entry.MotionHeadingDeg;
+        return true;
+    }
+
     /// <summary>
     /// Map-time scrubbing can jump backward; only checking (utc - cached) &gt; interval
     /// incorrectly treated older cached rings as fresh and drew them at a new subpoint.
@@ -61,5 +75,7 @@ internal sealed class SatelliteVisualCache
         public IReadOnlyList<GeoCoordinate> Footprint { get; set; } = [];
         public DateTime FootprintUtc;
         public double FootprintRadiusDeg;
+        public double? MotionHeadingDeg;
+        public DateTime MotionHeadingUtc;
     }
 }

--- a/OscarWatch.Core/Services/TrackingOrchestrator.cs
+++ b/OscarWatch.Core/Services/TrackingOrchestrator.cs
@@ -77,8 +77,20 @@ public sealed class TrackingOrchestrator
                 }
 
                 var subpoint = _propagator.GetSubpoint(sat.NoradId, utc);
-                var motionHeadingDeg = TryEstimateMotionHeadingDeg(sat.NoradId, utc, subpoint);
                 var cache = _visualCache.GetOrAdd(sat.NoradId);
+
+                double? motionHeadingDeg;
+                if (_visualCache.TryGetFreshMotionHeading(sat.NoradId, utc, out var cachedHeading))
+                {
+                    motionHeadingDeg = cachedHeading;
+                }
+                else
+                {
+                    motionHeadingDeg = TryEstimateMotionHeadingDeg(sat.NoradId, utc, subpoint);
+                    cache.MotionHeadingDeg = motionHeadingDeg;
+                    cache.MotionHeadingUtc = utc;
+                }
+
                 var altKm = TleAltitude.ResolveAltitudeKm(subpoint.AltitudeKm, sat);
 
                 IReadOnlyList<GeoCoordinate> groundTrack = [];


### PR DESCRIPTION

Caches the satellite motion heading computation in SatelliteVisualCache to avoid an extra GetSubpoint(utc + 45s) call per satellite per 250ms tick.

Before: Every tick computed heading for every satellite by propagating a second subpoint 45 seconds ahead. With 10 satellites at 4 Hz = 40 extra SGP4 calls/sec.

After: Heading is cached with an 8-second freshness window (same pattern as footprint/ground-track caching). Only recomputed when stale. Saves ~31/32 of the heading propagation calls.

Changes:

SatelliteVisualCache.cs — Added MotionHeadingDeg, MotionHeadingUtc to Entry class + TryGetFreshMotionHeading() method + 8s refresh interval
TrackingOrchestrator.cs — Checks cache before calling TryEstimateMotionHeadingDeg; stores result on miss