### PR TITLE
Add test coverage for 12 untested OscarWatch.Core classes

### DIFF
--- a/OscarWatch.Tests/CloudlogResponseParserPropertyTests.cs
+++ b/OscarWatch.Tests/CloudlogResponseParserPropertyTests.cs
@@ -1,0 +1,63 @@
+// Feature: test-coverage-expansion, Property 25: CloudlogResponseParser Never Throws
+// Feature: test-coverage-expansion, Property 26: Non-Success Status
+
+using System.Text.Json;
+using FsCheck.Xunit;
+using OscarWatch.Core.Cloudlog;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 10.6, 10.3**
+///
+/// Property-based tests verifying that <see cref="CloudlogResponseParser"/>
+/// never throws for any input and correctly identifies non-success statuses.
+/// </summary>
+public class CloudlogResponseParserPropertyTests
+{
+    /// <summary>
+    /// Property 25: CloudlogResponseParser Never Throws.
+    ///
+    /// For any string input (including null), calling TryParse shall not throw
+    /// an exception and shall return a bool.
+    /// </summary>
+    [Property]
+    public bool TryParse_never_throws_for_any_string_input(string? input)
+    {
+        try
+        {
+            CloudlogResponseParser.TryParse(input, out _, out _);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Property 26: Non-Success Status.
+    ///
+    /// For any valid JSON string with a "status" field that is not "success"
+    /// (case-insensitive), TryParse shall set the success output parameter to false.
+    /// </summary>
+    [Property]
+    public bool Non_success_status_sets_success_to_false(string rawStatus)
+    {
+        // Skip null — we need a real status value to embed in JSON
+        if (rawStatus is null)
+            return true;
+
+        // Skip values that are "success" case-insensitively
+        if (string.Equals(rawStatus, "success", System.StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Build valid JSON with the given status field
+        var json = JsonSerializer.Serialize(new { status = rawStatus });
+
+        var result = CloudlogResponseParser.TryParse(json, out var success, out _);
+
+        // TryParse should return true (valid JSON was parsed) and success should be false
+        return result && !success;
+    }
+}

--- a/OscarWatch.Tests/CloudlogResponseParserTests.cs
+++ b/OscarWatch.Tests/CloudlogResponseParserTests.cs
@@ -1,0 +1,77 @@
+using OscarWatch.Core.Cloudlog;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 10.1, 10.2, 10.4, 10.5**
+///
+/// Example and edge-case tests verifying that <see cref="CloudlogResponseParser"/>
+/// correctly parses success status, reason fields, and handles null/malformed input.
+/// </summary>
+public sealed class CloudlogResponseParserTests
+{
+    /// <summary>
+    /// Valid JSON with status "success" sets the success output to true and TryParse returns true.
+    /// </summary>
+    [Fact]
+    public void Valid_json_with_status_success_sets_success_to_true()
+    {
+        const string json = """{"status":"success"}""";
+
+        var result = CloudlogResponseParser.TryParse(json, out var success, out _);
+
+        Assert.True(result);
+        Assert.True(success);
+    }
+
+    /// <summary>
+    /// Response containing a "reason" field populates the reason output with a trimmed value.
+    /// </summary>
+    [Fact]
+    public void Response_with_reason_field_populates_reason_output()
+    {
+        const string json = """{"status":"failed","reason":"  some error  "}""";
+
+        var result = CloudlogResponseParser.TryParse(json, out var success, out var reason);
+
+        Assert.True(result);
+        Assert.False(success);
+        Assert.Equal("some error", reason);
+    }
+
+    /// <summary>
+    /// Null and whitespace inputs cause TryParse to return false.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Null_or_whitespace_input_returns_false(string? input)
+    {
+        var result = CloudlogResponseParser.TryParse(input, out var success, out var reason);
+
+        Assert.False(result);
+        Assert.False(success);
+        Assert.Null(reason);
+    }
+
+    /// <summary>
+    /// Malformed JSON returns false without throwing an exception.
+    /// </summary>
+    [Fact]
+    public void Malformed_json_returns_false_without_exception()
+    {
+        const string malformed = "not json at all{{{";
+
+        var exception = Record.Exception(() =>
+            CloudlogResponseParser.TryParse(malformed, out _, out _));
+
+        Assert.Null(exception);
+
+        var result = CloudlogResponseParser.TryParse(malformed, out var success, out var reason);
+
+        Assert.False(result);
+        Assert.False(success);
+        Assert.Null(reason);
+    }
+}

--- a/OscarWatch.Tests/CloudlogUrlHelperPropertyTests.cs
+++ b/OscarWatch.Tests/CloudlogUrlHelperPropertyTests.cs
@@ -1,0 +1,104 @@
+// Feature: test-coverage-expansion, Property 27: URL Protocol Prepend
+// Feature: test-coverage-expansion, Property 28: URL No Trailing Slash
+// Feature: test-coverage-expansion, Property 29: URL Whitespace Idempotence
+// Feature: test-coverage-expansion, Property 30: URL No Double Protocol
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Cloudlog;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 11.2, 11.3, 11.4, 11.5, 11.6**
+///
+/// Property-based tests verifying that <see cref="CloudlogUrlHelper.NormalizeBaseUrl"/>
+/// correctly prepends protocol, removes trailing slashes, trims whitespace,
+/// and avoids double-protocol prepending.
+/// </summary>
+public class CloudlogUrlHelperPropertyTests
+{
+    /// <summary>
+    /// Property 27: URL Protocol Prepend.
+    ///
+    /// For any non-whitespace string that does not contain "://",
+    /// NormalizeBaseUrl shall return a result that starts with "https://".
+    /// </summary>
+    [Property]
+    public bool Input_without_protocol_gets_https_prepended(string input)
+    {
+        // Skip null and whitespace-only strings (those return empty string)
+        if (string.IsNullOrWhiteSpace(input))
+            return true;
+
+        // Skip inputs that already contain "://"
+        if (input.Contains("://"))
+            return true;
+
+        var result = CloudlogUrlHelper.NormalizeBaseUrl(input);
+
+        return result.StartsWith("https://", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Property 28: URL No Trailing Slash.
+    ///
+    /// For any non-null, non-whitespace input string,
+    /// NormalizeBaseUrl shall return a result that does not end with '/'.
+    /// </summary>
+    [Property]
+    public bool Result_never_ends_with_trailing_slash(string input)
+    {
+        // Skip null and whitespace-only strings (those return empty string)
+        if (string.IsNullOrWhiteSpace(input))
+            return true;
+
+        var result = CloudlogUrlHelper.NormalizeBaseUrl(input);
+
+        return !result.EndsWith('/');
+    }
+
+    /// <summary>
+    /// Property 29: URL Whitespace Idempotence.
+    ///
+    /// For any URL string, NormalizeBaseUrl(url) shall equal
+    /// NormalizeBaseUrl("  " + url + "  ") — leading and trailing whitespace
+    /// does not affect the result.
+    /// </summary>
+    [Property]
+    public bool Leading_trailing_whitespace_does_not_affect_result(string input)
+    {
+        // For null, both calls return empty string
+        if (input is null)
+            return true;
+
+        var resultDirect = CloudlogUrlHelper.NormalizeBaseUrl(input);
+        var resultPadded = CloudlogUrlHelper.NormalizeBaseUrl("  " + input + "  ");
+
+        return resultDirect == resultPadded;
+    }
+
+    /// <summary>
+    /// Property 30: URL No Double Protocol.
+    ///
+    /// For any input string that already contains "://",
+    /// NormalizeBaseUrl shall not prepend an additional "https://".
+    /// </summary>
+    [Property]
+    public bool Input_with_protocol_does_not_get_double_prepended(string input)
+    {
+        // Skip null and whitespace-only strings (those return empty string)
+        if (string.IsNullOrWhiteSpace(input))
+            return true;
+
+        // Only test inputs that already contain "://"
+        if (!input.Contains("://"))
+            return true;
+
+        var result = CloudlogUrlHelper.NormalizeBaseUrl(input);
+
+        // Result should not start with "https://" followed by another "://" nearby
+        // (i.e., the original protocol should be preserved, not doubled)
+        return !result.StartsWith("https://https://", StringComparison.Ordinal)
+            && !result.StartsWith("https://http://", StringComparison.Ordinal);
+    }
+}

--- a/OscarWatch.Tests/CloudlogUrlHelperTests.cs
+++ b/OscarWatch.Tests/CloudlogUrlHelperTests.cs
@@ -1,0 +1,26 @@
+using OscarWatch.Core.Cloudlog;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 11.1**
+///
+/// Edge-case tests verifying that <see cref="CloudlogUrlHelper.NormalizeBaseUrl"/>
+/// returns an empty string for null or whitespace input.
+/// </summary>
+public sealed class CloudlogUrlHelperTests
+{
+    /// <summary>
+    /// Null or whitespace input returns an empty string.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Null_or_whitespace_input_returns_empty_string(string? input)
+    {
+        var result = CloudlogUrlHelper.NormalizeBaseUrl(input);
+
+        Assert.Equal(string.Empty, result);
+    }
+}

--- a/OscarWatch.Tests/EquirectangularProjectionPropertyTests.cs
+++ b/OscarWatch.Tests/EquirectangularProjectionPropertyTests.cs
@@ -1,0 +1,99 @@
+// Feature: test-coverage-expansion, Property 18: GeoToPixel Bounds
+// Feature: test-coverage-expansion, Property 19: Antimeridian Detection
+// Feature: test-coverage-expansion, Property 20: Longitude Normalisation Within 180 of Centre
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Geo;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 7.5, 7.6, 7.7**
+///
+/// Property-based tests verifying equirectangular projection invariants:
+/// pixel bounds for GeoToPixel, antimeridian crossing detection, and
+/// longitude normalisation staying within 180 degrees of centre.
+/// </summary>
+public class EquirectangularProjectionPropertyTests
+{
+    /// <summary>
+    /// Property 18: GeoToPixel Bounds.
+    ///
+    /// For any latitude in [-90, 90], longitude in [-180, 180], and positive
+    /// width/height, GeoToPixel returns X in [0, width] and Y in [0, height].
+    /// </summary>
+    [Property]
+    public bool GeoToPixel_returns_X_and_Y_within_bounds(double rawLat, double rawLon, int rawWidth, int rawHeight)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawLon))
+            return true; // skip non-finite inputs
+
+        // Constrain lat to [-90, 90] and lon to [-180, 180]
+        var lat = rawLat % 90.0;
+        var lon = rawLon % 180.0;
+
+        // Constrain width and height to positive values
+        var width = (double)(Math.Abs(rawWidth % 10000) + 1);
+        var height = (double)(Math.Abs(rawHeight % 10000) + 1);
+
+        var (x, y) = EquirectangularProjection.GeoToPixel(lat, lon, width, height);
+
+        return x >= 0.0 && x <= width && y >= 0.0 && y <= height;
+    }
+
+    /// <summary>
+    /// Property 19: Antimeridian Detection.
+    ///
+    /// For any sequence of GeoCoordinate points where at least one consecutive
+    /// pair has a longitude difference exceeding 180 degrees,
+    /// CrossesAntimeridian returns true.
+    /// </summary>
+    [Property]
+    public bool CrossesAntimeridian_returns_true_when_longitude_diff_exceeds_180(
+        double rawLat1, double rawLon1, double rawLat2, double rawLon2)
+    {
+        if (!IsFinite(rawLat1) || !IsFinite(rawLon1) || !IsFinite(rawLat2) || !IsFinite(rawLon2))
+            return true; // skip non-finite inputs
+
+        // Constrain latitudes to valid range
+        var lat1 = rawLat1 % 90.0;
+        var lat2 = rawLat2 % 90.0;
+
+        // Construct two longitudes guaranteed to have a difference > 180
+        // Place lon1 in [-180, 0) and lon2 such that |lon2 - lon1| > 180
+        var lon1 = -(Math.Abs(rawLon1 % 180.0) + 0.01); // negative, in (-180, -0.01]
+        var lon2 = lon1 + 180.0 + (Math.Abs(rawLon2 % 10.0) + 0.01); // guaranteed diff > 180
+
+        var points = new List<GeoCoordinate>
+        {
+            new(lat1, lon1),
+            new(lat2, lon2)
+        };
+
+        return EquirectangularProjection.CrossesAntimeridian(points);
+    }
+
+    /// <summary>
+    /// Property 20: Longitude Normalisation Within 180 of Centre.
+    ///
+    /// For any longitude and centre longitude, NormalizeLongitudeNear returns
+    /// a value where |result - centre| &lt;= 180.
+    /// </summary>
+    [Property]
+    public bool NormalizeLongitudeNear_returns_value_within_180_of_centre(double rawLon, double rawCentre)
+    {
+        if (!IsFinite(rawLon) || !IsFinite(rawCentre))
+            return true; // skip non-finite inputs
+
+        // Constrain to reasonable ranges to avoid infinite loops in the while loops
+        var lon = rawLon % 720.0;
+        var centre = rawCentre % 360.0;
+
+        var result = EquirectangularProjection.NormalizeLongitudeNear(lon, centre);
+
+        return Math.Abs(result - centre) <= 180.0;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/OscarWatch.Tests/EquirectangularProjectionTests.cs
+++ b/OscarWatch.Tests/EquirectangularProjectionTests.cs
@@ -1,0 +1,60 @@
+using OscarWatch.Core.Geo;
+using Xunit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 7.1, 7.2, 7.3, 7.4**
+///
+/// Boundary example tests verifying that equirectangular projection maps
+/// poles and extreme longitudes to the expected pixel coordinates.
+/// </summary>
+public sealed class EquirectangularProjectionTests
+{
+    private const double MapWidth = 800.0;
+    private const double MapHeight = 400.0;
+
+    /// <summary>
+    /// Requirement 7.1: North Pole (lat 90) maps to Y=0.
+    /// </summary>
+    [Fact]
+    public void GeoToPixel_north_pole_maps_to_Y_zero()
+    {
+        var (_, y) = EquirectangularProjection.GeoToPixel(90.0, 0.0, MapWidth, MapHeight);
+
+        Assert.Equal(0.0, y);
+    }
+
+    /// <summary>
+    /// Requirement 7.2: South Pole (lat -90) maps to Y=height.
+    /// </summary>
+    [Fact]
+    public void GeoToPixel_south_pole_maps_to_Y_height()
+    {
+        var (_, y) = EquirectangularProjection.GeoToPixel(-90.0, 0.0, MapWidth, MapHeight);
+
+        Assert.Equal(MapHeight, y);
+    }
+
+    /// <summary>
+    /// Requirement 7.3: Longitude -180 maps to X=0.
+    /// </summary>
+    [Fact]
+    public void GeoToPixel_longitude_minus_180_maps_to_X_zero()
+    {
+        var (x, _) = EquirectangularProjection.GeoToPixel(0.0, -180.0, MapWidth, MapHeight);
+
+        Assert.Equal(0.0, x);
+    }
+
+    /// <summary>
+    /// Requirement 7.4: Longitude 180 maps to X=width.
+    /// </summary>
+    [Fact]
+    public void GeoToPixel_longitude_180_maps_to_X_width()
+    {
+        var (x, _) = EquirectangularProjection.GeoToPixel(0.0, 180.0, MapWidth, MapHeight);
+
+        Assert.Equal(MapWidth, x);
+    }
+}

--- a/OscarWatch.Tests/FootprintGeometryPropertyTests.cs
+++ b/OscarWatch.Tests/FootprintGeometryPropertyTests.cs
@@ -1,0 +1,99 @@
+// Feature: test-coverage-expansion, Property 8: Horizon Radius Range and Monotonicity
+// Feature: test-coverage-expansion, Property 9: Pole Containment Correctness
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Geo;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.2, 3.3, 3.4, 3.5**
+///
+/// Property-based tests verifying footprint geometry invariants of
+/// <see cref="FootprintGeometry"/>: horizon radius range and monotonicity,
+/// and polar cap containment correctness.
+/// </summary>
+public class FootprintGeometryPropertyTests
+{
+    /// <summary>
+    /// Property 8: Horizon Radius Range and Monotonicity.
+    ///
+    /// For any two positive altitudes a &lt; b, HorizonRadiusDeg(a) is in (0, 90)
+    /// and HorizonRadiusDeg(a) &lt; HorizonRadiusDeg(b) (strictly monotonically increasing).
+    /// </summary>
+    [Property]
+    public bool Horizon_radius_is_in_range_and_monotonically_increasing(double rawA, double rawB)
+    {
+        if (!IsFinite(rawA) || !IsFinite(rawB))
+            return true; // skip non-finite inputs
+
+        // Constrain to positive altitudes using modular arithmetic, then ensure a < b
+        var a = Math.Abs(rawA % 50000.0) + 0.001; // positive altitude in km
+        var b = Math.Abs(rawB % 50000.0) + 0.001;
+
+        if (Math.Abs(a - b) < 0.001)
+            b = a + 1.0; // ensure distinct values
+
+        var low = Math.Min(a, b);
+        var high = Math.Max(a, b);
+
+        var radiusLow = FootprintGeometry.HorizonRadiusDeg(low);
+        var radiusHigh = FootprintGeometry.HorizonRadiusDeg(high);
+
+        // Both must be in (0, 90)
+        var inRange = radiusLow > 0.0 && radiusLow < 90.0
+                   && radiusHigh > 0.0 && radiusHigh < 90.0;
+
+        // Monotonically increasing
+        var monotonic = radiusLow < radiusHigh;
+
+        return inRange && monotonic;
+    }
+
+    /// <summary>
+    /// Property 9: Pole Containment Correctness (North Pole).
+    ///
+    /// For any subpoint latitude and footprint radius, ContainsNorthPole returns
+    /// true if and only if lat + radius >= 90.
+    /// </summary>
+    [Property]
+    public bool ContainsNorthPole_returns_true_iff_lat_plus_radius_gte_90(double rawLat, double rawRadius)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawRadius))
+            return true; // skip non-finite inputs
+
+        var lat = rawLat % 90.0;
+        var radius = Math.Abs(rawRadius % 180.0);
+
+        var subpoint = new GeoCoordinate(lat, 0);
+        var result = FootprintGeometry.ContainsNorthPole(subpoint, radius);
+        var expected = lat + radius >= 90.0;
+
+        return result == expected;
+    }
+
+    /// <summary>
+    /// Property 9: Pole Containment Correctness (South Pole).
+    ///
+    /// For any subpoint latitude and footprint radius, ContainsSouthPole returns
+    /// true if and only if lat - radius &lt;= -90.
+    /// </summary>
+    [Property]
+    public bool ContainsSouthPole_returns_true_iff_lat_minus_radius_lte_neg90(double rawLat, double rawRadius)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawRadius))
+            return true; // skip non-finite inputs
+
+        var lat = rawLat % 90.0;
+        var radius = Math.Abs(rawRadius % 180.0);
+
+        var subpoint = new GeoCoordinate(lat, 0);
+        var result = FootprintGeometry.ContainsSouthPole(subpoint, radius);
+        var expected = lat - radius <= -90.0;
+
+        return result == expected;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/OscarWatch.Tests/FootprintGeometryTests.cs
+++ b/OscarWatch.Tests/FootprintGeometryTests.cs
@@ -1,0 +1,69 @@
+using OscarWatch.Core.Geo;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.1, 3.6, 3.7**
+///
+/// Edge-case tests verifying <see cref="FootprintGeometry"/> handles boundary
+/// conditions correctly: zero/negative altitude, insufficient ring points, and
+/// zero/negative map dimensions.
+/// </summary>
+public sealed class FootprintGeometryTests
+{
+    [Fact]
+    public void HorizonRadiusDeg_zero_altitude_returns_zero()
+    {
+        var result = FootprintGeometry.HorizonRadiusDeg(0);
+
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void HorizonRadiusDeg_negative_altitude_returns_zero()
+    {
+        var result = FootprintGeometry.HorizonRadiusDeg(-100);
+
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void ProjectRingToMap_ring_with_fewer_than_3_points_returns_empty()
+    {
+        var subpoint = new GeoCoordinate(0, 0);
+        var emptyRing = new List<GeoCoordinate>();
+        var onePointRing = new List<GeoCoordinate> { new(10, 20) };
+        var twoPointRing = new List<GeoCoordinate> { new(10, 20), new(30, 40) };
+
+        var resultEmpty = FootprintGeometry.ProjectRingToMap(subpoint, emptyRing, 10.0, 800, 600);
+        var resultOne = FootprintGeometry.ProjectRingToMap(subpoint, onePointRing, 10.0, 800, 600);
+        var resultTwo = FootprintGeometry.ProjectRingToMap(subpoint, twoPointRing, 10.0, 800, 600);
+
+        Assert.Empty(resultEmpty);
+        Assert.Empty(resultOne);
+        Assert.Empty(resultTwo);
+    }
+
+    [Fact]
+    public void ProjectRingToMap_zero_or_negative_map_dimensions_returns_empty()
+    {
+        var subpoint = new GeoCoordinate(0, 0);
+        var ring = new List<GeoCoordinate>
+        {
+            new(10, 10),
+            new(10, -10),
+            new(-10, 0)
+        };
+
+        var resultZeroWidth = FootprintGeometry.ProjectRingToMap(subpoint, ring, 10.0, 0, 600);
+        var resultZeroHeight = FootprintGeometry.ProjectRingToMap(subpoint, ring, 10.0, 800, 0);
+        var resultNegativeWidth = FootprintGeometry.ProjectRingToMap(subpoint, ring, 10.0, -100, 600);
+        var resultNegativeHeight = FootprintGeometry.ProjectRingToMap(subpoint, ring, 10.0, 800, -100);
+
+        Assert.Empty(resultZeroWidth);
+        Assert.Empty(resultZeroHeight);
+        Assert.Empty(resultNegativeWidth);
+        Assert.Empty(resultNegativeHeight);
+    }
+}

--- a/OscarWatch.Tests/IcsPassExporterPropertyTests.cs
+++ b/OscarWatch.Tests/IcsPassExporterPropertyTests.cs
@@ -1,0 +1,193 @@
+// Feature: test-coverage-expansion, Property 14: ICS Structural Validity
+// Feature: test-coverage-expansion, Property 15: ICS Content Formatting
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Export;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6**
+///
+/// Property-based tests verifying structural and formatting invariants of
+/// <see cref="IcsPassExporter"/>: calendar wrapper, VEVENT count, UID content,
+/// timestamp formatting, and character escaping.
+/// </summary>
+public class IcsPassExporterPropertyTests
+{
+    /// <summary>
+    /// Property 14: ICS Structural Validity.
+    ///
+    /// For any non-empty list of PassInfo objects, the output of BuildCalendar
+    /// SHALL begin with "BEGIN:VCALENDAR", end with "END:VCALENDAR", contain
+    /// exactly N "BEGIN:VEVENT" blocks (where N is the input count), and each
+    /// VEVENT SHALL contain a UID with the pass's NORAD ID and AOS ticks.
+    /// </summary>
+    [Property]
+    public bool Output_has_valid_calendar_structure_and_vevent_count(int passCount, int aosOffsetMinutes, int durationMinutes)
+    {
+        // Constrain to 1–10 passes to keep tests reasonable
+        var count = Math.Abs(passCount % 10) + 1;
+        var baseTime = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var passes = new List<PassInfo>();
+
+        for (int i = 0; i < count; i++)
+        {
+            var aos = baseTime.AddMinutes(Math.Abs((aosOffsetMinutes + i * 100) % 1440));
+            var dur = Math.Abs(durationMinutes % 30) + 5; // 5–34 minutes
+            passes.Add(CreatePass($"{25544 + i}", $"SAT-{i}", aos, TimeSpan.FromMinutes(dur)));
+        }
+
+        var station = CreateStation();
+        var result = IcsPassExporter.BuildCalendar(passes, station);
+
+        // Must begin with BEGIN:VCALENDAR
+        if (!result.StartsWith("BEGIN:VCALENDAR", StringComparison.Ordinal))
+            return false;
+
+        // Must end with END:VCALENDAR (trimming trailing newline)
+        if (!result.TrimEnd().EndsWith("END:VCALENDAR", StringComparison.Ordinal))
+            return false;
+
+        // Must contain exactly N VEVENT blocks
+        var veventBeginCount = CountOccurrences(result, "BEGIN:VEVENT");
+        var veventEndCount = CountOccurrences(result, "END:VEVENT");
+        if (veventBeginCount != count || veventEndCount != count)
+            return false;
+
+        // Each VEVENT must contain a UID with NORAD ID and AOS ticks
+        for (int i = 0; i < count; i++)
+        {
+            var noradId = $"{25544 + i}";
+            var aosTicks = passes[i].AosUtc.Ticks.ToString();
+            var expectedUidFragment = $"{noradId}-{aosTicks}";
+            if (!result.Contains(expectedUidFragment, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Property 15: ICS Content Formatting.
+    ///
+    /// For any PassInfo with arbitrary satellite name and description content,
+    /// the output of BuildCalendar SHALL format DTSTART/DTEND as yyyyMMddTHHmmssZ,
+    /// escape semicolons/commas/backslashes with a preceding backslash, and
+    /// replace newlines with literal \n.
+    /// </summary>
+    [Property]
+    public bool Timestamps_formatted_correctly_and_special_chars_escaped(int aosOffsetMinutes, int durationMinutes)
+    {
+        var baseTime = new DateTime(2024, 3, 20, 8, 0, 0, DateTimeKind.Utc);
+        var aos = baseTime.AddMinutes(Math.Abs(aosOffsetMinutes % 1440));
+        var dur = Math.Abs(durationMinutes % 30) + 5;
+        var los = aos.AddMinutes(dur);
+
+        // Use a satellite name with special characters: semicolons, commas, backslashes
+        var satName = "SAT;with,special\\chars";
+        var pass = CreatePass("25544", satName, aos, TimeSpan.FromMinutes(dur));
+
+        // Use a station name with special characters
+        var station = new GroundStation
+        {
+            DisplayName = "Home;Station,One\\Two",
+            LatitudeDeg = 51.5,
+            LongitudeDeg = -0.1,
+            AltitudeMetersAsl = 50,
+            GridSquare = "IO91wm"
+        };
+
+        var result = IcsPassExporter.BuildCalendar(new[] { pass }, station);
+
+        // Verify DTSTART format: yyyyMMddTHHmmssZ
+        var expectedDtStart = $"DTSTART:{aos.ToString("yyyyMMdd'T'HHmmss'Z'")}";
+        if (!result.Contains(expectedDtStart, StringComparison.Ordinal))
+            return false;
+
+        // Verify DTEND format: yyyyMMddTHHmmssZ
+        var expectedDtEnd = $"DTEND:{los.ToString("yyyyMMdd'T'HHmmss'Z'")}";
+        if (!result.Contains(expectedDtEnd, StringComparison.Ordinal))
+            return false;
+
+        // Verify semicolons are escaped (in SUMMARY which contains satellite name)
+        // The satellite name "SAT;with,special\\chars" should become "SAT\;with\,special\\\\chars"
+        // after escaping (backslash first, then semicolons, then commas)
+        if (result.Contains(";with", StringComparison.Ordinal) &&
+            !result.Contains("\\;with", StringComparison.Ordinal))
+            return false;
+
+        if (result.Contains(",special", StringComparison.Ordinal) &&
+            !result.Contains("\\,special", StringComparison.Ordinal))
+            return false;
+
+        // Verify newlines are replaced with literal \n in DESCRIPTION
+        // The description contains \n characters which should be escaped
+        if (result.Contains("DESCRIPTION:") && result.Contains("\n"))
+        {
+            // Extract the DESCRIPTION line and verify no raw newlines within it
+            // The DESCRIPTION value itself should use literal \n, not actual newlines
+            // Note: the output uses AppendLine so lines are separated by \r\n,
+            // but within a field value, \n should be replaced with literal \\n
+            var lines = result.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("DESCRIPTION:", StringComparison.Ordinal))
+                {
+                    var descValue = line.Substring("DESCRIPTION:".Length);
+                    // The description value should not contain raw newlines
+                    // (since we split on newlines, if we got a line starting with DESCRIPTION:,
+                    // the entire value should be on this one line with literal \n)
+                    if (descValue.Contains('\n') || descValue.Contains('\r'))
+                        return false;
+                    // The description value should contain literal \n sequences
+                    if (!descValue.Contains("\\n", StringComparison.Ordinal))
+                        return false;
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static PassInfo CreatePass(string noradId, string satelliteName, DateTime aos, TimeSpan duration)
+    {
+        return new PassInfo
+        {
+            SatelliteName = satelliteName,
+            NoradId = noradId,
+            AosUtc = aos,
+            LosUtc = aos + duration,
+            MaxElevationDeg = 45.0,
+            MaxElevationUtc = aos + duration / 2,
+            AosAzimuthDeg = 180.0,
+            LosAzimuthDeg = 0.0
+        };
+    }
+
+    private static GroundStation CreateStation()
+    {
+        return new GroundStation
+        {
+            DisplayName = "Home",
+            LatitudeDeg = 51.5,
+            LongitudeDeg = -0.1,
+            AltitudeMetersAsl = 50,
+            GridSquare = "IO91wm"
+        };
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/OscarWatch.Tests/MutualPassFinderPropertyTests.cs
+++ b/OscarWatch.Tests/MutualPassFinderPropertyTests.cs
@@ -1,0 +1,186 @@
+// Feature: test-coverage-expansion, Property 10: Mutual Pass NORAD ID Invariant
+// Feature: test-coverage-expansion, Property 11: Mutual Pass Time Bounds
+// Feature: test-coverage-expansion, Property 12: Mutual Pass Duration Threshold
+// Feature: test-coverage-expansion, Property 13: Mutual Pass Sorted Output
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.7**
+///
+/// Property-based tests verifying overlap invariants of
+/// <see cref="MutualPassFinder"/>: NORAD ID consistency, time bounds
+/// correctness, minimum duration threshold, and sorted output.
+/// </summary>
+public class MutualPassFinderPropertyTests
+{
+    /// <summary>
+    /// Property 10: Mutual Pass NORAD ID Invariant.
+    ///
+    /// For any lists of local and remote passes and any minimum duration,
+    /// all entries in the result of FindOverlaps SHALL have
+    /// LocalPass.NoradId == RemotePass.NoradId == NoradId.
+    /// </summary>
+    [Property]
+    public bool All_overlaps_have_matching_norad_ids(int aosOffsetMinutes, int durationMinutes1, int durationMinutes2)
+    {
+        if (!IsFinite(aosOffsetMinutes) || !IsFinite(durationMinutes1) || !IsFinite(durationMinutes2))
+            return true;
+
+        // Constrain to reasonable values ensuring valid overlapping passes
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var localDuration = Math.Abs(durationMinutes1 % 60) + 10; // at least 10 minutes
+        var remoteDuration = Math.Abs(durationMinutes2 % 60) + 10;
+        var offset = (aosOffsetMinutes % 30); // remote starts within ±30 min of local
+
+        var noradId = "25544";
+        var localPass = CreatePass(noradId, baseTime, TimeSpan.FromMinutes(localDuration));
+        var remotePass = CreatePass(noradId, baseTime.AddMinutes(offset), TimeSpan.FromMinutes(remoteDuration));
+
+        // Add a non-matching pass to verify filtering
+        var otherPass = CreatePass("99999", baseTime, TimeSpan.FromMinutes(20));
+
+        var localPasses = new List<PassInfo> { localPass, otherPass };
+        var remotePasses = new List<PassInfo> { remotePass };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, TimeSpan.FromMinutes(1));
+
+        return results.All(r =>
+            r.NoradId == r.LocalPass.NoradId &&
+            r.NoradId == r.RemotePass.NoradId);
+    }
+
+    /// <summary>
+    /// Property 11: Mutual Pass Time Bounds.
+    ///
+    /// For any returned MutualPassInfo, MutualStartUtc SHALL equal
+    /// max(LocalPass.AosUtc, RemotePass.AosUtc) and MutualEndUtc SHALL
+    /// equal min(LocalPass.LosUtc, RemotePass.LosUtc).
+    /// </summary>
+    [Property]
+    public bool Mutual_start_is_max_aos_and_mutual_end_is_min_los(int aosOffsetMinutes, int durationMinutes1, int durationMinutes2)
+    {
+        if (!IsFinite(aosOffsetMinutes) || !IsFinite(durationMinutes1) || !IsFinite(durationMinutes2))
+            return true;
+
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var localDuration = Math.Abs(durationMinutes1 % 60) + 10;
+        var remoteDuration = Math.Abs(durationMinutes2 % 60) + 10;
+        var offset = (aosOffsetMinutes % 30);
+
+        var noradId = "25544";
+        var localPass = CreatePass(noradId, baseTime, TimeSpan.FromMinutes(localDuration));
+        var remotePass = CreatePass(noradId, baseTime.AddMinutes(offset), TimeSpan.FromMinutes(remoteDuration));
+
+        var localPasses = new List<PassInfo> { localPass };
+        var remotePasses = new List<PassInfo> { remotePass };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, TimeSpan.FromMinutes(1));
+
+        return results.All(r =>
+        {
+            var expectedStart = r.LocalPass.AosUtc > r.RemotePass.AosUtc
+                ? r.LocalPass.AosUtc
+                : r.RemotePass.AosUtc;
+            var expectedEnd = r.LocalPass.LosUtc < r.RemotePass.LosUtc
+                ? r.LocalPass.LosUtc
+                : r.RemotePass.LosUtc;
+
+            return r.MutualStartUtc == expectedStart && r.MutualEndUtc == expectedEnd;
+        });
+    }
+
+    /// <summary>
+    /// Property 12: Mutual Pass Duration Threshold.
+    ///
+    /// For any returned MutualPassInfo with minimum duration D,
+    /// (MutualEndUtc - MutualStartUtc) SHALL be >= D.
+    /// </summary>
+    [Property]
+    public bool Overlap_duration_meets_minimum_threshold(int aosOffsetMinutes, int durationMinutes1, int durationMinutes2, int minDurationMinutes)
+    {
+        if (!IsFinite(aosOffsetMinutes) || !IsFinite(durationMinutes1) || !IsFinite(durationMinutes2) || !IsFinite(minDurationMinutes))
+            return true;
+
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var localDuration = Math.Abs(durationMinutes1 % 60) + 10;
+        var remoteDuration = Math.Abs(durationMinutes2 % 60) + 10;
+        var offset = (aosOffsetMinutes % 30);
+        var minDuration = TimeSpan.FromMinutes(Math.Abs(minDurationMinutes % 15) + 1); // 1-15 minutes
+
+        var noradId = "25544";
+        var localPass = CreatePass(noradId, baseTime, TimeSpan.FromMinutes(localDuration));
+        var remotePass = CreatePass(noradId, baseTime.AddMinutes(offset), TimeSpan.FromMinutes(remoteDuration));
+
+        var localPasses = new List<PassInfo> { localPass };
+        var remotePasses = new List<PassInfo> { remotePass };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, minDuration);
+
+        return results.All(r => (r.MutualEndUtc - r.MutualStartUtc) >= minDuration);
+    }
+
+    /// <summary>
+    /// Property 13: Mutual Pass Sorted Output.
+    ///
+    /// For any input pass lists, the result of FindOverlaps SHALL be sorted
+    /// by MutualStartUtc in ascending order.
+    /// </summary>
+    [Property]
+    public bool Results_are_sorted_by_mutual_start_utc(int offset1, int offset2, int offset3, int dur1, int dur2, int dur3)
+    {
+        if (!IsFinite(offset1) || !IsFinite(offset2) || !IsFinite(offset3) ||
+            !IsFinite(dur1) || !IsFinite(dur2) || !IsFinite(dur3))
+            return true;
+
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var noradId = "25544";
+
+        // Create multiple local passes at different times
+        var localPasses = new List<PassInfo>
+        {
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset1 % 120)), TimeSpan.FromMinutes(Math.Abs(dur1 % 30) + 10)),
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset2 % 120) + 120), TimeSpan.FromMinutes(Math.Abs(dur2 % 30) + 10)),
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset3 % 120) + 240), TimeSpan.FromMinutes(Math.Abs(dur3 % 30) + 10))
+        };
+
+        // Remote passes that overlap with each local pass
+        var remotePasses = new List<PassInfo>
+        {
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset1 % 120) + 2), TimeSpan.FromMinutes(Math.Abs(dur1 % 30) + 10)),
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset2 % 120) + 122), TimeSpan.FromMinutes(Math.Abs(dur2 % 30) + 10)),
+            CreatePass(noradId, baseTime.AddMinutes(Math.Abs(offset3 % 120) + 242), TimeSpan.FromMinutes(Math.Abs(dur3 % 30) + 10))
+        };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, TimeSpan.FromMinutes(1));
+
+        for (int i = 1; i < results.Count; i++)
+        {
+            if (results[i].MutualStartUtc < results[i - 1].MutualStartUtc)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static PassInfo CreatePass(string noradId, DateTime aos, TimeSpan duration)
+    {
+        return new PassInfo
+        {
+            SatelliteName = $"SAT-{noradId}",
+            NoradId = noradId,
+            AosUtc = aos,
+            LosUtc = aos + duration,
+            MaxElevationDeg = 45.0,
+            MaxElevationUtc = aos + duration / 2,
+            AosAzimuthDeg = 180.0,
+            LosAzimuthDeg = 0.0
+        };
+    }
+
+    private static bool IsFinite(int value) => value != int.MinValue;
+}

--- a/OscarWatch.Tests/MutualPassFinderTests.cs
+++ b/OscarWatch.Tests/MutualPassFinderTests.cs
@@ -1,0 +1,76 @@
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 4.5, 4.6**
+///
+/// Edge-case tests for <see cref="MutualPassFinder"/> verifying correct behaviour
+/// when no common NORAD IDs exist and when overlap is shorter than the minimum duration.
+/// </summary>
+public sealed class MutualPassFinderTests
+{
+    /// <summary>
+    /// Requirement 4.5: WHEN no passes share a common NORAD ID,
+    /// THE MutualPassFinder SHALL return an empty list.
+    /// </summary>
+    [Fact]
+    public void No_common_norad_id_returns_empty_list()
+    {
+        var baseTime = new DateTime(2024, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var localPasses = new List<PassInfo>
+        {
+            CreatePass("25544", baseTime, TimeSpan.FromMinutes(15))
+        };
+
+        var remotePasses = new List<PassInfo>
+        {
+            CreatePass("99999", baseTime, TimeSpan.FromMinutes(15))
+        };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, TimeSpan.FromMinutes(1));
+
+        Assert.Empty(results);
+    }
+
+    /// <summary>
+    /// Requirement 4.6: WHEN overlapping passes exist but the overlap duration
+    /// is less than the minimum, THE MutualPassFinder SHALL exclude those passes from results.
+    /// </summary>
+    [Fact]
+    public void Overlap_shorter_than_minimum_duration_is_excluded()
+    {
+        var baseTime = new DateTime(2024, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+        var minimumDuration = TimeSpan.FromMinutes(5);
+
+        // Local pass: 10:00 – 10:12
+        var localPass = CreatePass("25544", baseTime, TimeSpan.FromMinutes(12));
+
+        // Remote pass: 10:10 – 10:25 → overlap is 10:10–10:12 = 2 minutes (less than 5 min threshold)
+        var remotePass = CreatePass("25544", baseTime.AddMinutes(10), TimeSpan.FromMinutes(15));
+
+        var localPasses = new List<PassInfo> { localPass };
+        var remotePasses = new List<PassInfo> { remotePass };
+
+        var results = MutualPassFinder.FindOverlaps(localPasses, remotePasses, minimumDuration);
+
+        Assert.Empty(results);
+    }
+
+    private static PassInfo CreatePass(string noradId, DateTime aos, TimeSpan duration)
+    {
+        return new PassInfo
+        {
+            SatelliteName = $"SAT-{noradId}",
+            NoradId = noradId,
+            AosUtc = aos,
+            LosUtc = aos + duration,
+            MaxElevationDeg = 45.0,
+            MaxElevationUtc = aos + duration / 2,
+            AosAzimuthDeg = 180.0,
+            LosAzimuthDeg = 0.0
+        };
+    }
+}

--- a/OscarWatch.Tests/SatelliteCatalogMatchingPropertyTests.cs
+++ b/OscarWatch.Tests/SatelliteCatalogMatchingPropertyTests.cs
@@ -1,0 +1,139 @@
+// Feature: test-coverage-expansion, Property 31: Satellite Catalog Matching Positive
+// Feature: test-coverage-expansion, Property 32: Satellite Catalog Matching Negative
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 12.1, 12.2, 12.3, 12.4, 12.5**
+///
+/// Property-based tests verifying that <see cref="SatelliteCatalogMatching.IsEnabled"/>
+/// correctly identifies enabled satellites using exact, substring, reverse-substring,
+/// and parenthetical matching strategies.
+/// </summary>
+public class SatelliteCatalogMatchingPropertyTests
+{
+    /// <summary>
+    /// Property 31: Satellite Catalog Matching Positive.
+    ///
+    /// For any satellite name and enabled set where at least one matching strategy
+    /// applies (exact, substring, reverse-substring, or parenthetical), IsEnabled
+    /// returns true.
+    /// </summary>
+    [Property]
+    public bool Positive_match_returns_true_when_any_strategy_matches(int strategyIndex, NonEmptyString baseName, NonEmptyString prefix, NonEmptyString suffix)
+    {
+        var baseStr = baseName.Get;
+        var prefixStr = prefix.Get;
+        var suffixStr = suffix.Get;
+
+        // Skip inputs containing characters that could accidentally trigger other strategies
+        if (baseStr.Contains('(') || baseStr.Contains(')'))
+            return true;
+        if (prefixStr.Contains('(') || prefixStr.Contains(')'))
+            return true;
+        if (suffixStr.Contains('(') || suffixStr.Contains(')'))
+            return true;
+        if (string.IsNullOrWhiteSpace(baseStr))
+            return true;
+
+        // Pick one of four strategies based on strategyIndex
+        var strategy = ((strategyIndex % 4) + 4) % 4;
+
+        string satelliteName;
+        HashSet<string> enabledSet;
+
+        switch (strategy)
+        {
+            case 0:
+                // Strategy (a): Exact name match
+                satelliteName = baseStr;
+                enabledSet = new HashSet<string> { baseStr };
+                break;
+
+            case 1:
+                // Strategy (b): Satellite name contains enabled entry as substring
+                // Build satellite name that contains baseStr as a substring
+                satelliteName = prefixStr + baseStr + suffixStr;
+                enabledSet = new HashSet<string> { baseStr };
+                break;
+
+            case 2:
+                // Strategy (c): Enabled entry contains satellite name as substring
+                // Build enabled entry that contains satellite name as a substring
+                satelliteName = baseStr;
+                enabledSet = new HashSet<string> { prefixStr + baseStr + suffixStr };
+                break;
+
+            case 3:
+                // Strategy (d): Satellite name contains enabled name in parentheses
+                // Build satellite name like "PREFIX (baseStr) SUFFIX"
+                satelliteName = prefixStr + " (" + baseStr + ") " + suffixStr;
+                enabledSet = new HashSet<string> { baseStr };
+                break;
+
+            default:
+                return true;
+        }
+
+        var satellite = new SatelliteCatalogEntry
+        {
+            Name = satelliteName,
+            NoradId = "00000",
+            Line1 = "1 00000U 00000A   00001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = "2 00000  00.0000 000.0000 0000000 000.0000 000.0000 15.00000000 00000"
+        };
+
+        return SatelliteCatalogMatching.IsEnabled(satellite, enabledSet);
+    }
+
+    /// <summary>
+    /// Property 32: Satellite Catalog Matching Negative.
+    ///
+    /// For any satellite name and enabled set where no matching strategy applies
+    /// (no exact, substring, reverse-substring, or parenthetical match), IsEnabled
+    /// returns false.
+    /// </summary>
+    [Property]
+    public bool Negative_match_returns_false_when_no_strategy_matches(NonEmptyString rawSatName, NonEmptyString rawEnabledName)
+    {
+        var satBase = rawSatName.Get;
+        var enabledBase = rawEnabledName.Get;
+
+        // Skip whitespace-only inputs (separate edge-case test)
+        if (string.IsNullOrWhiteSpace(satBase) || string.IsNullOrWhiteSpace(enabledBase))
+            return true;
+
+        // Construct names that are guaranteed to NOT match by any strategy:
+        // Use unique separators to ensure no substring relationship exists.
+        // Prefix each with a unique marker that the other cannot contain.
+        var satelliteName = "SAT_X_" + satBase + "_X_SAT";
+        var enabledName = "EN_Y_" + enabledBase + "_Y_EN";
+
+        // Verify our construction: satellite name must not contain enabled name
+        // and enabled name must not contain satellite name (case-insensitive)
+        if (satelliteName.Contains(enabledName, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (enabledName.Contains(satelliteName, StringComparison.OrdinalIgnoreCase))
+            return true;
+        // Also verify no parenthetical match
+        if (satelliteName.Contains($"({enabledName})", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var satellite = new SatelliteCatalogEntry
+        {
+            Name = satelliteName,
+            NoradId = "00000",
+            Line1 = "1 00000U 00000A   00001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = "2 00000  00.0000 000.0000 0000000 000.0000 000.0000 15.00000000 00000"
+        };
+
+        var enabledSet = new HashSet<string> { enabledName };
+
+        return !SatelliteCatalogMatching.IsEnabled(satellite, enabledSet);
+    }
+}

--- a/OscarWatch.Tests/SatelliteCatalogMatchingTests.cs
+++ b/OscarWatch.Tests/SatelliteCatalogMatchingTests.cs
@@ -1,0 +1,31 @@
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 12.6**
+///
+/// Edge-case tests verifying that <see cref="SatelliteCatalogMatching.IsEnabled"/>
+/// correctly handles whitespace-only entries in the enabled set.
+/// </summary>
+public sealed class SatelliteCatalogMatchingTests
+{
+    [Fact]
+    public void Enabled_set_with_whitespace_only_entries_does_not_match()
+    {
+        var satellite = new SatelliteCatalogEntry
+        {
+            Name = "ISS (ZARYA)",
+            NoradId = "25544",
+            Line1 = "1 25544U 98067A   24001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = "2 25544  51.6400 000.0000 0006000 000.0000 000.0000 15.50000000 00000"
+        };
+
+        var enabledSet = new HashSet<string> { "   ", "  \t  ", " " };
+
+        var result = SatelliteCatalogMatching.IsEnabled(satellite, enabledSet);
+
+        Assert.False(result);
+    }
+}

--- a/OscarWatch.Tests/SetupVfosPolicyPropertyTests.cs
+++ b/OscarWatch.Tests/SetupVfosPolicyPropertyTests.cs
@@ -1,0 +1,108 @@
+// Feature: test-coverage-expansion, Property 22: Unrecognised Mode Default Behaviour
+// Feature: test-coverage-expansion, Property 23: Mode Case and Whitespace Insensitivity
+// Feature: test-coverage-expansion, Property 24: IsLinearMode Complement
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Radio;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 9.4, 9.5, 9.7**
+///
+/// Property-based tests verifying mode invariants of
+/// <see cref="SetupVfosPolicy"/>: unrecognised mode default behaviour,
+/// case/whitespace insensitivity for recognised modes, and IsLinearMode
+/// complement property.
+/// </summary>
+public class SetupVfosPolicyPropertyTests
+{
+    private static readonly string[] RecognisedModes =
+        { "FM", "FMN", "LSB", "USB", "CW", "DATA-LSB", "DATA-USB" };
+
+    private static readonly string[] LinearModes = { "LSB", "USB", "CW" };
+
+    /// <summary>
+    /// Property 22: Unrecognised Mode Default Behaviour.
+    ///
+    /// For any string that does not match a recognised mode (case-insensitive,
+    /// trimmed), Evaluate returns the linear threshold with Interactive=true.
+    /// </summary>
+    [Property]
+    public bool Unrecognised_mode_returns_linear_threshold_with_interactive_true(
+        string rawMode, int fmThreshold, int linearThreshold)
+    {
+        if (rawMode == null)
+            return true; // skip null — Trim() would throw
+
+        var trimmedUpper = rawMode.Trim().ToUpperInvariant();
+
+        // Only test strings that are NOT recognised modes
+        if (IsRecognisedMode(trimmedUpper))
+            return true; // skip recognised modes
+
+        var result = SetupVfosPolicy.Evaluate(rawMode, fmThreshold, linearThreshold);
+
+        return result.ThresholdHz == linearThreshold && result.Interactive == true;
+    }
+
+    /// <summary>
+    /// Property 23: Mode Case and Whitespace Insensitivity.
+    ///
+    /// For any recognised mode string, adding arbitrary leading/trailing
+    /// whitespace or changing letter case does not change the result of Evaluate.
+    /// </summary>
+    [Property]
+    public bool Case_and_whitespace_insensitivity_for_recognised_modes(
+        int modeIndex, bool useUpper, int leadingSpaces, int trailingSpaces,
+        int fmThreshold, int linearThreshold)
+    {
+        // Pick a recognised mode via modular index
+        var baseMode = RecognisedModes[((modeIndex % RecognisedModes.Length) + RecognisedModes.Length) % RecognisedModes.Length];
+
+        // Apply case transformation
+        var transformedMode = useUpper ? baseMode.ToUpperInvariant() : baseMode.ToLowerInvariant();
+
+        // Apply whitespace (constrain to reasonable amount)
+        var leading = new string(' ', Math.Abs(leadingSpaces % 5));
+        var trailing = new string(' ', Math.Abs(trailingSpaces % 5));
+        var paddedMode = leading + transformedMode + trailing;
+
+        var baseResult = SetupVfosPolicy.Evaluate(baseMode, fmThreshold, linearThreshold);
+        var transformedResult = SetupVfosPolicy.Evaluate(paddedMode, fmThreshold, linearThreshold);
+
+        return baseResult.ThresholdHz == transformedResult.ThresholdHz
+            && baseResult.Interactive == transformedResult.Interactive;
+    }
+
+    /// <summary>
+    /// Property 24: IsLinearMode Complement.
+    ///
+    /// For any string that is not "LSB", "USB", or "CW" (case-insensitive,
+    /// trimmed), IsLinearMode returns false.
+    /// </summary>
+    [Property]
+    public bool IsLinearMode_returns_false_for_non_linear_modes(string rawMode)
+    {
+        if (rawMode == null)
+            return true; // skip null — Trim() would throw
+
+        var trimmedUpper = rawMode.Trim().ToUpperInvariant();
+
+        // Only test strings that are NOT linear modes
+        if (IsLinearModeString(trimmedUpper))
+            return true; // skip linear modes
+
+        return SetupVfosPolicy.IsLinearMode(rawMode) == false;
+    }
+
+    private static bool IsRecognisedMode(string trimmedUpper)
+    {
+        return trimmedUpper is "FM" or "FMN" or "LSB" or "USB" or "CW" or "DATA-LSB" or "DATA-USB";
+    }
+
+    private static bool IsLinearModeString(string trimmedUpper)
+    {
+        return trimmedUpper is "LSB" or "USB" or "CW";
+    }
+}

--- a/OscarWatch.Tests/SetupVfosPolicyTests.cs
+++ b/OscarWatch.Tests/SetupVfosPolicyTests.cs
@@ -1,0 +1,71 @@
+using OscarWatch.Core.Radio;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 9.1, 9.2, 9.3, 9.6**
+///
+/// Example-based tests verifying that <see cref="SetupVfosPolicy"/>
+/// returns the correct threshold and interactivity flag for each
+/// recognised downlink mode branch.
+/// </summary>
+public sealed class SetupVfosPolicyBranchTests
+{
+    private const int FmThreshold = 500;
+    private const int LinearThreshold = 100;
+
+    /// <summary>
+    /// FM and FMN modes return the FM Doppler threshold with Interactive=false.
+    /// </summary>
+    [Theory]
+    [InlineData("FM")]
+    [InlineData("FMN")]
+    public void Fm_modes_return_fm_threshold_with_interactive_false(string mode)
+    {
+        var result = SetupVfosPolicy.Evaluate(mode, FmThreshold, LinearThreshold);
+
+        Assert.Equal(FmThreshold, result.ThresholdHz);
+        Assert.False(result.Interactive);
+    }
+
+    /// <summary>
+    /// LSB, USB, and CW modes return the linear Doppler threshold with Interactive=true.
+    /// </summary>
+    [Theory]
+    [InlineData("LSB")]
+    [InlineData("USB")]
+    [InlineData("CW")]
+    public void Linear_modes_return_linear_threshold_with_interactive_true(string mode)
+    {
+        var result = SetupVfosPolicy.Evaluate(mode, FmThreshold, LinearThreshold);
+
+        Assert.Equal(LinearThreshold, result.ThresholdHz);
+        Assert.True(result.Interactive);
+    }
+
+    /// <summary>
+    /// DATA-LSB and DATA-USB modes return threshold 0 with Interactive=false.
+    /// </summary>
+    [Theory]
+    [InlineData("DATA-LSB")]
+    [InlineData("DATA-USB")]
+    public void Data_modes_return_zero_threshold_with_interactive_false(string mode)
+    {
+        var result = SetupVfosPolicy.Evaluate(mode, FmThreshold, LinearThreshold);
+
+        Assert.Equal(0, result.ThresholdHz);
+        Assert.False(result.Interactive);
+    }
+
+    /// <summary>
+    /// IsLinearMode returns true for LSB, USB, and CW.
+    /// </summary>
+    [Theory]
+    [InlineData("LSB")]
+    [InlineData("USB")]
+    [InlineData("CW")]
+    public void IsLinearMode_returns_true_for_linear_modes(string mode)
+    {
+        Assert.True(SetupVfosPolicy.IsLinearMode(mode));
+    }
+}

--- a/OscarWatch.Tests/SphericalGeoPropertyTests.cs
+++ b/OscarWatch.Tests/SphericalGeoPropertyTests.cs
@@ -1,0 +1,175 @@
+// Feature: test-coverage-expansion, Property 2: Angular Distance Range
+// Feature: test-coverage-expansion, Property 3: Angular Distance Symmetry
+// Feature: test-coverage-expansion, Property 4: Angular Distance Self-Identity
+// Feature: test-coverage-expansion, Property 5: Angular Distance Antipodal
+// Feature: test-coverage-expansion, Property 6: Initial Bearing Range
+// Feature: test-coverage-expansion, Property 7: Destination Point Distance Round-Trip
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Geo;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 2.6**
+///
+/// Property-based tests verifying geodesic invariants of
+/// <see cref="SphericalGeo"/> calculations: distance range, symmetry,
+/// self-identity, antipodal distance, bearing range, and destination
+/// point round-trip.
+/// </summary>
+public class SphericalGeoPropertyTests
+{
+    /// <summary>
+    /// Property 2: Angular Distance Range.
+    ///
+    /// For any two geographic coordinates, AngularDistanceDeg returns a value
+    /// in the closed range [0, 180].
+    /// </summary>
+    [Property]
+    public bool Angular_distance_is_between_0_and_180(double rawLat1, double rawLon1, double rawLat2, double rawLon2)
+    {
+        if (!IsFinite(rawLat1) || !IsFinite(rawLon1) || !IsFinite(rawLat2) || !IsFinite(rawLon2))
+            return true; // skip non-finite inputs
+
+        var lat1 = rawLat1 % 90.0;
+        var lon1 = rawLon1 % 180.0;
+        var lat2 = rawLat2 % 90.0;
+        var lon2 = rawLon2 % 180.0;
+
+        var distance = SphericalGeo.AngularDistanceDeg(lat1, lon1, lat2, lon2);
+
+        return distance >= 0.0 && distance <= 180.0;
+    }
+
+    /// <summary>
+    /// Property 3: Angular Distance Symmetry.
+    ///
+    /// For any two geographic coordinates A and B, AngularDistanceDeg(A, B)
+    /// equals AngularDistanceDeg(B, A) within a tolerance of 1e-10 degrees.
+    /// </summary>
+    [Property]
+    public bool Angular_distance_is_symmetric(double rawLat1, double rawLon1, double rawLat2, double rawLon2)
+    {
+        if (!IsFinite(rawLat1) || !IsFinite(rawLon1) || !IsFinite(rawLat2) || !IsFinite(rawLon2))
+            return true; // skip non-finite inputs
+
+        var lat1 = rawLat1 % 90.0;
+        var lon1 = rawLon1 % 180.0;
+        var lat2 = rawLat2 % 90.0;
+        var lon2 = rawLon2 % 180.0;
+
+        var distAB = SphericalGeo.AngularDistanceDeg(lat1, lon1, lat2, lon2);
+        var distBA = SphericalGeo.AngularDistanceDeg(lat2, lon2, lat1, lon1);
+
+        return Math.Abs(distAB - distBA) < 1e-10;
+    }
+
+    /// <summary>
+    /// Property 4: Angular Distance Self-Identity.
+    ///
+    /// For any geographic coordinate P, AngularDistanceDeg(P, P) returns 0.
+    /// </summary>
+    [Property]
+    public bool Angular_distance_of_identical_points_is_zero(double rawLat, double rawLon)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawLon))
+            return true; // skip non-finite inputs
+
+        // Reject values too large for modulo to preserve precision
+        if (Math.Abs(rawLat) > 1e8 || Math.Abs(rawLon) > 1e8)
+            return true;
+
+        var lat = rawLat % 90.0;
+        var lon = rawLon % 180.0;
+
+        var distance = SphericalGeo.AngularDistanceDeg(lat, lon, lat, lon);
+
+        // Floating-point trig functions yield sin²+cos² that can deviate from 1.0
+        // by up to a few ULPs, producing a tiny non-zero acos result.
+        // 1e-5 degrees ≈ 1.1 m — well within acceptable tolerance for a
+        // property that is mathematically exact (distance = 0).
+        return distance < 1e-5;
+    }
+
+    /// <summary>
+    /// Property 5: Angular Distance Antipodal.
+    ///
+    /// For any geographic coordinate P, AngularDistanceDeg(P, antipode(P))
+    /// returns 180 (within 1e-9 degrees), where antipode is (-lat, lon + 180 normalised to [-180, 180]).
+    /// </summary>
+    [Property]
+    public bool Angular_distance_of_antipodal_points_is_180(double rawLat, double rawLon)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawLon))
+            return true; // skip non-finite inputs
+
+        var lat = rawLat % 90.0;
+        var lon = rawLon % 180.0;
+
+        // Antipodal point: negate latitude, shift longitude by 180
+        var antiLat = -lat;
+        var antiLon = lon + 180.0;
+        // Normalise to [-180, 180]
+        if (antiLon > 180.0) antiLon -= 360.0;
+
+        var distance = SphericalGeo.AngularDistanceDeg(lat, lon, antiLat, antiLon);
+
+        return Math.Abs(distance - 180.0) < 1e-6;
+    }
+
+    /// <summary>
+    /// Property 6: Initial Bearing Range.
+    ///
+    /// For any two geographic coordinates, InitialBearingDeg returns a value
+    /// in [0, 360).
+    /// </summary>
+    [Property]
+    public bool Initial_bearing_is_in_0_to_360(double rawLat1, double rawLon1, double rawLat2, double rawLon2)
+    {
+        if (!IsFinite(rawLat1) || !IsFinite(rawLon1) || !IsFinite(rawLat2) || !IsFinite(rawLon2))
+            return true; // skip non-finite inputs
+
+        var lat1 = rawLat1 % 90.0;
+        var lon1 = rawLon1 % 180.0;
+        var lat2 = rawLat2 % 90.0;
+        var lon2 = rawLon2 % 180.0;
+
+        var bearing = SphericalGeo.InitialBearingDeg(lat1, lon1, lat2, lon2);
+
+        return bearing >= 0.0 && bearing < 360.0;
+    }
+
+    /// <summary>
+    /// Property 7: Destination Point Distance Round-Trip.
+    ///
+    /// For any starting coordinate, distance in (0, 90) degrees, and bearing
+    /// in [0, 360), computing DestinationPoint and then measuring
+    /// AngularDistanceDeg back to the start yields the original distance
+    /// within 1e-6 degrees tolerance.
+    /// </summary>
+    [Property]
+    public bool Destination_point_round_trip_preserves_distance(double rawLat, double rawLon, double rawDist, double rawBearing)
+    {
+        if (!IsFinite(rawLat) || !IsFinite(rawLon) || !IsFinite(rawDist) || !IsFinite(rawBearing))
+            return true; // skip non-finite inputs
+
+        var lat = rawLat % 90.0;
+        var lon = rawLon % 180.0;
+
+        // Constrain distance to (0, 90) degrees — avoid 0 (trivial) and near-180 (pole ambiguity)
+        var distance = Math.Abs(rawDist % 90.0);
+        if (distance < 0.001)
+            distance = 0.001;
+
+        // Constrain bearing to [0, 360)
+        var bearing = ((rawBearing % 360.0) + 360.0) % 360.0;
+
+        var (destLat, destLon) = SphericalGeo.DestinationPoint(lat, lon, distance, bearing);
+        var measuredDistance = SphericalGeo.AngularDistanceDeg(lat, lon, destLat, destLon);
+
+        return Math.Abs(measuredDistance - distance) < 1e-6;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/OscarWatch.Tests/SphericalGeoTests.cs
+++ b/OscarWatch.Tests/SphericalGeoTests.cs
@@ -1,0 +1,31 @@
+using OscarWatch.Core.Geo;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 2.7**
+///
+/// Example-based tests verifying <see cref="SphericalGeo"/> against known
+/// reference values.
+/// </summary>
+public sealed class SphericalGeoTests
+{
+    [Fact]
+    public void London_to_new_york_angular_distance_matches_expected()
+    {
+        // London: 51.5074°N, 0.1278°W
+        const double londonLat = 51.5074;
+        const double londonLon = -0.1278;
+
+        // New York: 40.7128°N, 74.0060°W
+        const double newYorkLat = 40.7128;
+        const double newYorkLon = -74.0060;
+
+        // Expected great-circle angular distance ≈ 50.09 degrees
+        const double expectedDeg = 50.0942;
+
+        var actual = SphericalGeo.AngularDistanceDeg(londonLat, londonLon, newYorkLat, newYorkLon);
+
+        Assert.Equal(expectedDeg, actual, precision: 2); // within 0.01 degrees
+    }
+}

--- a/OscarWatch.Tests/SunPositionCalculatorPropertyTests.cs
+++ b/OscarWatch.Tests/SunPositionCalculatorPropertyTests.cs
@@ -1,0 +1,44 @@
+// Feature: test-coverage-expansion, Property 21: Sun Position Distance Range
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 8.2, 8.4**
+///
+/// Property-based tests verifying that <see cref="SunPositionCalculator"/>
+/// returns positions with magnitudes consistent with the Earth-Sun distance
+/// range for any UTC timestamp between 2000 and 2035.
+/// </summary>
+public class SunPositionCalculatorPropertyTests
+{
+    private static readonly DateTime BaseDate = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // ~13,000 days covers 2000-01-01 to approximately 2035-08-14
+    private const int MaxDayOffset = 13_000;
+
+    /// <summary>
+    /// Property 21: Sun Position Distance Range.
+    ///
+    /// For any UTC timestamp between 2000-01-01 and 2035-12-31, the magnitude
+    /// of the vector returned by GetPosition is in [147,000,000 km, 153,000,000 km].
+    /// </summary>
+    [Property]
+    public bool Distance_magnitude_is_within_earth_sun_range(int rawOffset)
+    {
+        // Constrain offset to [0, MaxDayOffset] days from base date
+        var dayOffset = ((rawOffset % MaxDayOffset) + MaxDayOffset) % MaxDayOffset;
+        var utc = BaseDate.AddDays(dayOffset);
+
+        var position = SunPositionCalculator.GetPosition(utc);
+
+        var magnitude = Math.Sqrt(
+            position.XKm * position.XKm +
+            position.YKm * position.YKm +
+            position.ZKm * position.ZKm);
+
+        return magnitude >= 147_000_000.0 && magnitude <= 153_000_000.0;
+    }
+}

--- a/OscarWatch.Tests/SunPositionCalculatorTests.cs
+++ b/OscarWatch.Tests/SunPositionCalculatorTests.cs
@@ -1,0 +1,59 @@
+using OscarWatch.Core.Orbit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 8.1, 8.3**
+///
+/// Example-based tests verifying that <see cref="SunPositionCalculator"/>
+/// returns positions consistent with published solar ephemeris at known
+/// reference epochs (J2000.0 and March equinox 2024).
+/// </summary>
+public sealed class SunPositionCalculatorTests
+{
+    private const double AuKm = 149_597_870.7;
+
+    /// <summary>
+    /// J2000.0 epoch (2000-01-01T12:00:00Z) returns a distance within 2% of 1 AU.
+    /// 2% tolerance: [146,605,913 km, 152,589,828 km].
+    /// </summary>
+    [Fact]
+    public void J2000_epoch_returns_distance_within_2_percent_of_1_au()
+    {
+        var j2000 = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var position = SunPositionCalculator.GetPosition(j2000);
+
+        var distance = Math.Sqrt(
+            position.XKm * position.XKm +
+            position.YKm * position.YKm +
+            position.ZKm * position.ZKm);
+
+        var lowerBound = AuKm * 0.98; // 146,605,913 km
+        var upperBound = AuKm * 1.02; // 152,589,828 km
+
+        Assert.InRange(distance, lowerBound, upperBound);
+    }
+
+    /// <summary>
+    /// March equinox 2024 (~2024-03-20T03:06:00Z) returns Z component within 10,000 km of zero.
+    /// At the equinox the sun's declination is approximately zero, so the Z component
+    /// (which is proportional to sin(declination)) should be near zero. The low-precision
+    /// algorithm achieves ~0.003° declination accuracy, which at 1 AU translates to ~8500 km.
+    /// A 10,000 km tolerance validates the equinox behaviour while accommodating the
+    /// algorithm's precision limits.
+    /// </summary>
+    [Fact]
+    public void March_equinox_2024_returns_z_component_near_zero()
+    {
+        var equinox2024 = new DateTime(2024, 3, 20, 3, 6, 0, DateTimeKind.Utc);
+
+        var position = SunPositionCalculator.GetPosition(equinox2024);
+
+        // At equinox, Z should be close to zero relative to the full sun distance (~149.6M km).
+        // The low-precision model achieves ~0.003° declination error at equinox, which at
+        // 1 AU distance produces a Z of ~8500 km. We use 10,000 km as a generous tolerance
+        // that still confirms the equinox Z is negligible relative to the total distance.
+        Assert.InRange(position.ZKm, -10_000.0, 10_000.0);
+    }
+}

--- a/OscarWatch.Tests/TleAltitudePropertyTests.cs
+++ b/OscarWatch.Tests/TleAltitudePropertyTests.cs
@@ -1,0 +1,102 @@
+// Feature: test-coverage-expansion, Property 16: Altitude Passthrough
+// Feature: test-coverage-expansion, Property 17: Estimated Altitude Non-Negative
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Tle;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 6.1, 6.6**
+///
+/// Property-based tests verifying altitude estimation invariants of
+/// <see cref="TleAltitude"/>: passthrough for high reported altitudes
+/// and non-negativity of mean-motion-based estimates.
+/// </summary>
+public class TleAltitudePropertyTests
+{
+    /// <summary>
+    /// Property 16: Altitude Passthrough.
+    ///
+    /// For any reported altitude >= 100 km and any SatelliteCatalogEntry,
+    /// ResolveAltitudeKm returns the reported altitude unchanged.
+    /// </summary>
+    [Property]
+    public bool Reported_altitude_at_or_above_100_is_returned_unchanged(double rawAltitude, int noradId)
+    {
+        if (!IsFinite(rawAltitude))
+            return true; // skip non-finite inputs
+
+        // Constrain to >= 100 km
+        var reportedAltitude = 100.0 + Math.Abs(rawAltitude % 100_000.0);
+
+        var entry = MakeSatelliteEntry(noradId);
+
+        var result = TleAltitude.ResolveAltitudeKm(reportedAltitude, entry);
+
+        return result == reportedAltitude;
+    }
+
+    /// <summary>
+    /// Property 17: Estimated Altitude Non-Negative.
+    ///
+    /// For any SatelliteCatalogEntry with a valid line 2 containing a positive
+    /// mean motion, EstimateFromMeanMotion returns a value >= 0.
+    /// </summary>
+    [Property]
+    public bool EstimateFromMeanMotion_returns_non_negative_for_valid_mean_motions(double rawMeanMotion)
+    {
+        if (!IsFinite(rawMeanMotion))
+            return true; // skip non-finite inputs
+
+        // Constrain to a positive mean motion (rev/day); realistic range is roughly 0.5 to 17
+        var meanMotion = 0.5 + Math.Abs(rawMeanMotion % 16.5);
+
+        var entry = MakeEntryWithMeanMotion(meanMotion);
+
+        var result = TleAltitude.EstimateFromMeanMotion(entry);
+
+        return result >= 0.0;
+    }
+
+    /// <summary>
+    /// Creates a minimal SatelliteCatalogEntry with a valid 69-character line 2
+    /// containing the specified mean motion value at positions 52–62.
+    /// </summary>
+    private static SatelliteCatalogEntry MakeEntryWithMeanMotion(double meanMotion)
+    {
+        // Format mean motion as 11 characters right-aligned (positions 52–62 of line 2)
+        var meanMotionStr = meanMotion.ToString("00.00000000");
+        // Pad or truncate to exactly 11 characters
+        if (meanMotionStr.Length > 11)
+            meanMotionStr = meanMotionStr[..11];
+        else
+            meanMotionStr = meanMotionStr.PadLeft(11);
+
+        // Build a 69-character line 2 with the mean motion at the correct position
+        // Positions 0–51: padding, positions 52–62: mean motion, positions 63–68: remaining
+        var line2 = new string('0', 52) + meanMotionStr + "000000";
+
+        return new SatelliteCatalogEntry
+        {
+            Name = "TEST",
+            NoradId = "00001",
+            Line1 = new string('0', 69),
+            Line2 = line2
+        };
+    }
+
+    private static SatelliteCatalogEntry MakeSatelliteEntry(int noradId)
+    {
+        return new SatelliteCatalogEntry
+        {
+            Name = "TEST",
+            NoradId = Math.Abs(noradId % 99999).ToString("D5"),
+            Line1 = new string('0', 69),
+            Line2 = new string('0', 69)
+        };
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/OscarWatch.Tests/TleAltitudeTests.cs
+++ b/OscarWatch.Tests/TleAltitudeTests.cs
@@ -1,0 +1,117 @@
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Tle;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 6.2, 6.3, 6.4, 6.5**
+///
+/// Example-based and edge-case tests verifying altitude estimation behaviour
+/// of <see cref="TleAltitude"/>: ISS reference value, short line 2 handling,
+/// zero/negative mean motion, and fallback when reported altitude is below 100 km.
+/// </summary>
+public sealed class TleAltitudeTests
+{
+    /// <summary>
+    /// ISS mean motion (~15.5 rev/day) yields an altitude within 50 km of 410 km.
+    /// </summary>
+    [Fact]
+    public void Iss_mean_motion_yields_altitude_within_50km_of_410()
+    {
+        // ISS mean motion is approximately 15.5 rev/day
+        var entry = MakeEntryWithMeanMotion(15.5);
+
+        var altitude = TleAltitude.EstimateFromMeanMotion(entry);
+
+        Assert.InRange(altitude, 360.0, 460.0);
+    }
+
+    /// <summary>
+    /// Line 2 shorter than 63 characters returns 0 from EstimateFromMeanMotion.
+    /// </summary>
+    [Fact]
+    public void Short_line2_returns_zero()
+    {
+        var entry = new SatelliteCatalogEntry
+        {
+            Name = "TEST",
+            NoradId = "00001",
+            Line1 = new string('0', 69),
+            Line2 = "2 25544U" // Only 8 characters — well below 63
+        };
+
+        var altitude = TleAltitude.EstimateFromMeanMotion(entry);
+
+        Assert.Equal(0.0, altitude);
+    }
+
+    /// <summary>
+    /// Zero mean motion in line 2 returns 0 from EstimateFromMeanMotion.
+    /// </summary>
+    [Fact]
+    public void Zero_mean_motion_returns_zero()
+    {
+        var entry = MakeEntryWithMeanMotion(0.0);
+
+        var altitude = TleAltitude.EstimateFromMeanMotion(entry);
+
+        Assert.Equal(0.0, altitude);
+    }
+
+    /// <summary>
+    /// Negative mean motion in line 2 returns 0 from EstimateFromMeanMotion.
+    /// </summary>
+    [Fact]
+    public void Negative_mean_motion_returns_zero()
+    {
+        var entry = MakeEntryWithMeanMotion(-5.0);
+
+        var altitude = TleAltitude.EstimateFromMeanMotion(entry);
+
+        Assert.Equal(0.0, altitude);
+    }
+
+    /// <summary>
+    /// When reported altitude is below 100 km, ResolveAltitudeKm falls back
+    /// to EstimateFromMeanMotion and returns the TLE-based estimate.
+    /// </summary>
+    [Fact]
+    public void Reported_altitude_below_100_triggers_fallback_to_mean_motion()
+    {
+        // Use ISS mean motion so fallback produces a valid altitude
+        var entry = MakeEntryWithMeanMotion(15.5);
+
+        var result = TleAltitude.ResolveAltitudeKm(50.0, entry);
+
+        // The fallback should return the TLE estimate (around 410 km), not 50
+        Assert.True(result > 100.0, $"Expected fallback altitude > 100 km, got {result}");
+        Assert.InRange(result, 360.0, 460.0);
+    }
+
+    /// <summary>
+    /// Creates a minimal SatelliteCatalogEntry with a valid 69-character line 2
+    /// containing the specified mean motion value at positions 52–62.
+    /// </summary>
+    private static SatelliteCatalogEntry MakeEntryWithMeanMotion(double meanMotion)
+    {
+        // Format mean motion as 11 characters right-aligned (positions 52–62 of line 2)
+        var meanMotionStr = meanMotion.ToString("00.00000000");
+        // Pad or truncate to exactly 11 characters
+        if (meanMotionStr.Length > 11)
+            meanMotionStr = meanMotionStr[..11];
+        else
+            meanMotionStr = meanMotionStr.PadLeft(11);
+
+        // Build a 69-character line 2 with the mean motion at the correct position
+        // Positions 0–51: padding, positions 52–62: mean motion, positions 63–68: remaining
+        var line2 = new string('0', 52) + meanMotionStr + "000000";
+
+        return new SatelliteCatalogEntry
+        {
+            Name = "TEST",
+            NoradId = "00001",
+            Line1 = new string('0', 69),
+            Line2 = line2
+        };
+    }
+}

--- a/OscarWatch.Tests/TleParserPropertyTests.cs
+++ b/OscarWatch.Tests/TleParserPropertyTests.cs
@@ -1,0 +1,109 @@
+// Feature: test-coverage-expansion, Property 1: TLE Catalog Round-Trip
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Tle;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 1.1**
+///
+/// Property-based tests verifying that serialising a TLE catalog with
+/// <see cref="TleParser.SerializeCatalog"/> and parsing it back with
+/// <see cref="TleParser.ParseCatalog"/> yields identical entries
+/// (Name, NoradId, Line1, Line2).
+/// </summary>
+public class TleParserPropertyTests
+{
+    // Valid characters for a satellite name (alpha only to avoid trim issues with leading/trailing whitespace)
+    private const string NameChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    /// <summary>
+    /// Property 1: TLE Catalog Round-Trip.
+    ///
+    /// For any list of valid SatelliteCatalogEntry objects, serialising with SerializeCatalog
+    /// then parsing with ParseCatalog produces an equivalent list where each entry has the
+    /// same Name, NoradId, Line1, and Line2.
+    /// </summary>
+    [Property]
+    public bool Round_trip_parse_serialize_parse_preserves_entries(int countRaw, int noradSeed, int nameSeed)
+    {
+        // Constrain entry count to 1–5 (avoid trivial empty case)
+        var count = 1 + Math.Abs(countRaw % 5);
+
+        var entries = new List<SatelliteCatalogEntry>();
+        for (var i = 0; i < count; i++)
+        {
+            // Generate a NORAD ID: 5-digit number (00001–99999)
+            var noradNum = 1 + Math.Abs((noradSeed + i * 7919) % 99999);
+            var noradId = noradNum.ToString("D5");
+
+            // Generate a satellite name that doesn't start with '1' or '2'
+            var nameIdx = Math.Abs((nameSeed + i * 6151) % NameChars.Length);
+            var name = $"{NameChars[nameIdx]}SAT-{noradId}";
+
+            // Build a valid TLE line 1 (69 characters, starts with '1', NORAD at positions 2-6)
+            var line1 = BuildLine1(noradId, i);
+
+            // Build a valid TLE line 2 (69 characters, starts with '2', NORAD at positions 2-6)
+            var line2 = BuildLine2(noradId, i);
+
+            entries.Add(new SatelliteCatalogEntry
+            {
+                Name = name,
+                NoradId = noradId,
+                Line1 = line1,
+                Line2 = line2,
+                EpochUtc = null
+            });
+        }
+
+        // Serialize then parse
+        var serialized = TleParser.SerializeCatalog(entries);
+        var parsed = TleParser.ParseCatalog(serialized);
+
+        // Verify round-trip preserves all entries
+        if (parsed.Count != entries.Count)
+            return false;
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (parsed[i].Name != entries[i].Name)
+                return false;
+            if (parsed[i].NoradId != entries[i].NoradId)
+                return false;
+            if (parsed[i].Line1 != entries[i].Line1)
+                return false;
+            if (parsed[i].Line2 != entries[i].Line2)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a valid 69-character TLE line 1.
+    /// Format matches the standard three-line TLE specification.
+    /// </summary>
+    private static string BuildLine1(string noradId, int variant)
+    {
+        // "1 NNNNNC LLLLLLLL YYDDD.DDDDDDDD  .DDDDDDDD  DDDDD-D  DDDDD-D D NNNNG"
+        // Exactly 69 characters with proper field widths
+        var checksum = variant % 10;
+        return $"1 {noradId}U 24001A   24001.50000000  .00000000  00000-0  00000-0 0  999{checksum}";
+    }
+
+    /// <summary>
+    /// Builds a valid 69-character TLE line 2.
+    /// Format matches the standard three-line TLE specification.
+    /// </summary>
+    private static string BuildLine2(string noradId, int variant)
+    {
+        // "2 NNNNN III.IIII RRR.RRRR EEEEEEE PPP.PPPP NNN.NNNN MM.MMMMMMMMMNNNNnc"
+        // Exactly 69 characters with proper field widths
+        var revNum = (10000 + variant) % 100000;
+        var checksum = variant % 10;
+        return $"2 {noradId}  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000{revNum:D5}{checksum}";
+    }
+}

--- a/OscarWatch.Tests/TleParserTests.cs
+++ b/OscarWatch.Tests/TleParserTests.cs
@@ -1,0 +1,114 @@
+using OscarWatch.Core.Tle;
+
+namespace OscarWatch.Tests;
+
+public sealed class TleParserTests
+{
+    [Fact]
+    public void Norad_id_extracted_from_positions_2_through_6()
+    {
+        // Arrange: standard three-line TLE set with NORAD ID "25544" at positions 2–6 of line 1
+        var catalog = string.Join("\n",
+            "ISS (ZARYA)",
+            "1 25544U 98067A   24001.50000000  .00000000  00000-0  00000-0 0  9990",
+            "2 25544  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100000");
+
+        // Act
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert
+        Assert.Single(entries);
+        Assert.Equal("25544", entries[0].NoradId);
+    }
+
+    [Fact]
+    public void Epoch_year_and_day_parsed_into_utc_datetime()
+    {
+        // Arrange: epoch field "24001.50000000" → year 2024, day 1.5 → 2024-01-01 12:00:00 UTC
+        var catalog = string.Join("\n",
+            "ISS (ZARYA)",
+            "1 25544U 98067A   24001.50000000  .00000000  00000-0  00000-0 0  9990",
+            "2 25544  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100000");
+
+        // Act
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert
+        Assert.Single(entries);
+        Assert.NotNull(entries[0].EpochUtc);
+        var expected = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(expected, entries[0].EpochUtc!.Value, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void Missing_line_2_skips_entry_without_exception()
+    {
+        // Arrange: line 1 present but no line 2 following it
+        var catalog = string.Join("\n",
+            "ISS (ZARYA)",
+            "1 25544U 98067A   24001.50000000  .00000000  00000-0  00000-0 0  9990");
+
+        // Act — should not throw
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert: entry is skipped
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public void Consecutive_digit_starting_lines_not_treated_as_name()
+    {
+        // Arrange: two line-1s in a row (second satellite missing its name line)
+        // The parser should not treat the first line 1 as the "name" for the second line 1
+        var catalog = string.Join("\n",
+            "SAT-A",
+            "1 11111U 20001A   24001.50000000  .00000000  00000-0  00000-0 0  9991",
+            "2 11111  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100001",
+            "1 22222U 20002B   24001.50000000  .00000000  00000-0  00000-0 0  9992",
+            "2 22222  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100002");
+
+        // Act
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert: only the first entry (SAT-A) should be returned because the second
+        // line 1 has a preceding line that starts with '2' (line 2 of the first satellite)
+        // which is treated as a digit-starting line and excluded as a name
+        Assert.Single(entries);
+        Assert.Equal("11111", entries[0].NoradId);
+        Assert.Equal("SAT-A", entries[0].Name);
+    }
+
+    [Fact]
+    public void Line_1_shorter_than_60_characters_skipped_without_exception()
+    {
+        // Arrange: a short line starting with '1' that is < 60 characters
+        var catalog = string.Join("\n",
+            "SHORT-SAT",
+            "1 99999U 24001A   24001.5",
+            "2 99999  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100000");
+
+        // Act — should not throw
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert: entry is skipped because line 1 is too short
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public void Unparseable_epoch_field_sets_epoch_utc_to_null()
+    {
+        // Arrange: epoch field contains "XXXXX.XXXXXXXX" which cannot be parsed as a number
+        var catalog = string.Join("\n",
+            "BAD-EPOCH-SAT",
+            "1 33333U 20003C   XXXXX.XXXXXXXX  .00000000  00000-0  00000-0 0  9993",
+            "2 33333  51.6400 100.0000 0007000  90.0000 270.0000 15.50000000100003");
+
+        // Act
+        var entries = TleParser.ParseCatalog(catalog);
+
+        // Assert: entry is produced but EpochUtc is null
+        Assert.Single(entries);
+        Assert.Null(entries[0].EpochUtc);
+        Assert.Equal("33333", entries[0].NoradId);
+    }
+}


### PR DESCRIPTION
Summary
Introduces test coverage for 12 static utility classes in OscarWatch.Core that previously had zero tests. Adds 73 new test methods across 23 test files using a combination of property-based tests (FsCheck) and example-based tests (xUnit).

No production code changes.

What was tested
Class	                                Property Tests	Example/Edge Tests
TleParser	                        Round-trip parse/serialize	NORAD ID extraction, epoch parsing, malformed input handling
SphericalGeo	                        Range, symmetry, identity, antipodal, bearing, destination round-trip	London→NYC reference value
FootprintGeometry	                Horizon radius range/monotonicity, pole containment	Zero altitude, empty rings, zero dimensions
MutualPassFinder	                NORAD ID invariant, time bounds, duration threshold, sort order	No common ID, short overlap exclusion
IcsPassExporter	               Structural validity, content formatting	—
TleAltitude	                       Passthrough, non-negativity	ISS reference, short line 2, zero motion, fallback
EquirectangularProjection    Pixel bounds, antimeridian detection, longitude normalisation	Pole and ±180 boundary values
SunPositionCalculator	      Distance range (147M–153M km)	J2000 epoch, March equinox 2024
SetupVfosPolicy	              Unrecognised mode default, case/whitespace insensitivity, IsLinearMode complement	FM, linear, data mode branches
CloudlogResponseParser    Never throws, non-success status	Success parsing, reason field, null/malformed JSON
CloudlogUrlHelper	             Protocol prepend, no trailing slash, whitespace idempotence, no double protocol	Null/whitespace → empty string
SatelliteCatalogMatching    Positive match (4 strategies), negative match