### PR TITLE
Fix incomplete orbit ground track rendering

### DIFF
--- a/OscarWatch.Core/Geo/EquirectangularProjection.cs
+++ b/OscarWatch.Core/Geo/EquirectangularProjection.cs
@@ -210,8 +210,22 @@ public static class EquirectangularProjection
 
         foreach (var p in points)
         {
+            // NaN sentinel: explicit chain break from propagation gap
+            if (double.IsNaN(p.LatitudeDeg))
+            {
+                if (current is { Count: > 0 })
+                    segments.Add(current);
+                current = null;
+                prevPoint = null;
+                prevRawLon = null;
+                unwrappedLon = 0;
+                continue;
+            }
+
             if (prevRawLon is not null)
                 unwrappedLon += ShortestLongitudeDelta(unwrappedLon, p.LongitudeDeg);
+            else
+                unwrappedLon = p.LongitudeDeg;
 
             var pixel = GeoToPixel(p.LatitudeDeg, unwrappedLon, width, height);
             if (prevPoint is not null && current is { Count: > 0 })
@@ -219,7 +233,8 @@ public static class EquirectangularProjection
                 var last = current[^1];
                 var dx = Math.Abs(pixel.X - last.X);
                 var dy = Math.Abs(pixel.Y - last.Y);
-                if (dx > width / 2.0 && dy < height / 6.0)
+                if (dx > width / 2.0 && dy < height / 6.0
+                    && Math.Abs(ShortestLongitudeDelta(prevRawLon!.Value, p.LongitudeDeg)) >= 170.0)
                 {
                     if (current.Count >= 2)
                         segments.Add(current);

--- a/OscarWatch.Orbit/SampledGroundGeometry.cs
+++ b/OscarWatch.Orbit/SampledGroundGeometry.cs
@@ -22,7 +22,9 @@ public sealed class SampledGroundGeometry : IGroundGeometry
     {
         var usePropagator = _propagator.HasSatellite(satellite.NoradId);
         var orbit = usePropagator ? null : OrbitToolsMapping.CreateOrbit(satellite);
-        var points = new List<GeoCoordinate>();
+
+        // First pass: collect all sample results, recording nulls for failures
+        var rawPoints = new List<GeoCoordinate?>();
 
         for (var t = utcStart; t <= utcEnd; t += step)
         {
@@ -31,11 +33,61 @@ public sealed class SampledGroundGeometry : IGroundGeometry
                 var point = usePropagator
                     ? _propagator.GetSubpoint(satellite.NoradId, t)
                     : OrbitToolsMapping.ToGeoCoordinate(orbit!.PositionEci(t));
-                points.Add(point);
+                rawPoints.Add(point);
             }
             catch
             {
-                // skip decayed points
+                rawPoints.Add(null);
+            }
+        }
+
+        // Second pass: fill single nulls with interpolation, replace consecutive
+        // nulls with one NaN sentinel
+        var points = new List<GeoCoordinate>();
+        var i = 0;
+
+        while (i < rawPoints.Count)
+        {
+            if (rawPoints[i] is not null)
+            {
+                points.Add(rawPoints[i]!);
+                i++;
+            }
+            else
+            {
+                // Count consecutive failures
+                var gapStart = i;
+                while (i < rawPoints.Count && rawPoints[i] is null)
+                    i++;
+
+                var gapLength = i - gapStart;
+
+                if (gapLength == 1)
+                {
+                    // Single missing point: interpolate if both neighbours exist
+                    var prev = gapStart > 0 ? rawPoints[gapStart - 1] : null;
+                    var next = i < rawPoints.Count ? rawPoints[i] : null;
+
+                    if (prev is not null && next is not null)
+                    {
+                        // Linear interpolation of lat/lon/alt
+                        var interpLat = (prev.LatitudeDeg + next.LatitudeDeg) / 2.0;
+                        var interpLon = (prev.LongitudeDeg + next.LongitudeDeg) / 2.0;
+                        var interpAlt = (prev.AltitudeKm + next.AltitudeKm) / 2.0;
+                        points.Add(new GeoCoordinate(interpLat, interpLon, interpAlt));
+                    }
+                    else
+                    {
+                        // No previous success (first point fails) or next also fails:
+                        // insert a NaN sentinel
+                        points.Add(new GeoCoordinate(double.NaN, double.NaN));
+                    }
+                }
+                else
+                {
+                    // Consecutive missing points (≥2): insert a single NaN sentinel
+                    points.Add(new GeoCoordinate(double.NaN, double.NaN));
+                }
             }
         }
 

--- a/OscarWatch.Tests/GroundTrackSplitTests.cs
+++ b/OscarWatch.Tests/GroundTrackSplitTests.cs
@@ -46,8 +46,11 @@ public class GroundTrackSplitTests
     }
 
     [Fact]
-    public void SelectGroundTrackWrapOffset_skips_tiny_edge_stub()
+    public void SelectGroundTrackWrapOffset_falls_back_to_zero_for_tiny_edge_stub()
     {
+        // After bugfix 3.2, chains that fail the min-visible-span threshold at all
+        // offsets now fall back to offset 0 instead of returning null (which would
+        // silently drop the chain from rendering).
         const double w = 1200;
         var chain = new List<(double X, double Y)>
         {
@@ -55,7 +58,7 @@ public class GroundTrackSplitTests
             (-1150, 525)
         };
 
-        Assert.Null(WorldMapControl.SelectGroundTrackWrapOffset(chain, w));
+        Assert.Equal(0.0, WorldMapControl.SelectGroundTrackWrapOffset(chain, w));
     }
 
     [Fact]

--- a/OscarWatch.Tests/IncompleteOrbitTrackBugConditionPropertyTests.cs
+++ b/OscarWatch.Tests/IncompleteOrbitTrackBugConditionPropertyTests.cs
@@ -1,0 +1,460 @@
+// Feature: incomplete-orbit-tracks, Property 1: Bug Condition — Incomplete Orbit Track Rendering
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Controls;
+using OscarWatch.Core.Geo;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
+using OscarWatch.Orbit;
+using Xunit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+///
+/// Bug condition exploration tests: demonstrate the four sub-conditions of the
+/// incomplete orbit tracks bug on UNFIXED code.
+///
+/// These tests are EXPECTED TO FAIL on unfixed code — failure confirms the bugs exist.
+/// DO NOT attempt to fix the tests or the code when they fail.
+/// </summary>
+public class IncompleteOrbitTrackBugConditionPropertyTests
+{
+    private const double MapWidth = 1200.0;
+    private const double MapHeight = 600.0;
+
+    #region Sub-condition 1 — Polar pass chain break (via draw loop)
+
+    /// <summary>
+    /// Sub-condition 1: Polar pass rendered with gaps due to draw loop segment skipping.
+    ///
+    /// A satellite passing over high latitudes with coarse sampling produces large
+    /// latitude jumps between consecutive points. ProjectGroundTrackForDraw correctly
+    /// keeps the chain continuous (because the break condition requires dy &lt; h/6, and
+    /// polar passes have large dy). Now that the draw loop's redundant filter has been
+    /// removed (task 3.3), all segments in the chain are drawn without secondary filtering.
+    ///
+    /// Expected: ProjectGroundTrackForDraw produces a single continuous chain with all points.
+    /// </summary>
+    [Fact]
+    public void Polar_pass_coarse_sample_segments_not_skipped_by_draw_loop()
+    {
+        // Arrange: coarsely sampled polar pass with > 60° latitude jumps per step
+        var points = new List<GeoCoordinate>
+        {
+            new(-10.0, 30.0),   // Southern low latitude
+            new(55.0, 0.0),     // Northern mid (jump: 65°)
+            new(85.0, -40.0),   // Near pole (jump: 30°)
+            new(20.0, -100.0),  // Descending (jump: 65°)
+        };
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // ProjectGroundTrackForDraw keeps this as one chain (the tightened break condition
+        // requires a genuine antimeridian crossing with |shortestLonDelta| >= 170°, which
+        // these moderate longitude changes do not trigger)
+        Assert.Single(chains);
+        var chain = chains[0];
+        Assert.Equal(4, chain.Count);
+
+        // With the redundant draw loop filter removed, all segments in this single chain
+        // are now guaranteed to be drawn. No secondary filtering exists.
+    }
+
+    /// <summary>
+    /// Sub-condition 1: Polar pass property-based test.
+    ///
+    /// For any polar pass track where consecutive latitude changes exceed 60°,
+    /// ProjectGroundTrackForDraw should produce a single continuous chain containing
+    /// all points. With the redundant draw loop filter removed, all segments in
+    /// such a chain are guaranteed to be drawn.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Polar_pass_all_segments_drawable_regardless_of_dy(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a polar pass with large latitude steps
+        var startLat = rng.NextDouble() * 30.0 - 20.0;  // -20 to 10
+        var peakLat = 70.0 + rng.NextDouble() * 19.0;    // 70 to 89
+        var endLat = rng.NextDouble() * 30.0 - 20.0;     // -20 to 10
+        var startLon = rng.NextDouble() * 360.0 - 180.0;
+        var lonStep = -(rng.NextDouble() * 30.0 + 10.0);
+
+        var points = new List<GeoCoordinate>
+        {
+            new(startLat, NormaliseLon(startLon)),
+            new(peakLat, NormaliseLon(startLon + lonStep)),
+            new(endLat, NormaliseLon(startLon + lonStep * 2)),
+        };
+
+        // Verify no consecutive pair triggers antimeridian
+        for (var i = 0; i < points.Count - 1; i++)
+        {
+            var delta = Math.Abs(ShortestLongitudeDelta(points[i].LongitudeDeg, points[i + 1].LongitudeDeg));
+            if (delta >= 170.0)
+                return true; // Skip — antimeridian crossing
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // With the tightened break condition (requires |shortestLonDelta| >= 170°),
+        // polar passes with moderate longitude changes should form a single chain
+        // containing all 3 points.
+        if (chains.Count != 1)
+            return false; // Bug: chain was incorrectly broken
+
+        return chains[0].Count == 3;
+    }
+
+    #endregion
+
+    #region Sub-condition 2 — Short-span chain rejection
+
+    /// <summary>
+    /// Sub-condition 2: Short-span chain rejection (concrete case).
+    ///
+    /// Construct a 5-point chain that straddles the viewport right edge with
+    /// visible span &lt; 120px at all three offsets (0, +w, −w).
+    ///
+    /// At 1200px width, minVisibleSpanPx = max(120, 1200*0.08) = max(120, 96) = 120px.
+    /// Place points so that the visible portion at each offset is less than 120px.
+    ///
+    /// Expected: SelectGroundTrackWrapOffset returns non-null (offset 0 fallback).
+    /// Actual (unfixed): returns null, dropping the chain entirely.
+    /// </summary>
+    [Fact]
+    public void SelectGroundTrackWrapOffset_returns_non_null_for_short_span_chain()
+    {
+        // Arrange: 5 points clustered near x=1160..1240 (straddles right edge of 1200px viewport)
+        // At offset 0: visible from x=1160 to x=1200 → span = 40px < 120px
+        // At offset +w (1200): visible from x=2360 to x=2440 → entirely off right → span = 0px
+        // At offset -w (-1200): visible from x=-40 to x=40 → span = 40px < 120px
+        var chain = new List<(double X, double Y)>
+        {
+            (1160.0, 100.0),
+            (1180.0, 110.0),
+            (1200.0, 120.0),
+            (1220.0, 130.0),
+            (1240.0, 140.0),
+        };
+
+        // Act
+        var offset = WorldMapControl.SelectGroundTrackWrapOffset(chain, MapWidth);
+
+        // Assert: should return a valid offset (expected behaviour is fallback to 0)
+        // Bug: unfixed code returns null because no offset meets the 120px threshold
+        Assert.NotNull(offset);
+    }
+
+    /// <summary>
+    /// Sub-condition 2: Short-span chain rejection (property-based).
+    ///
+    /// For any chain with ≥2 points, SelectGroundTrackWrapOffset should never return null.
+    /// Even if the visible span is small, the chain should still be drawn at some offset.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool SelectGroundTrackWrapOffset_never_returns_null_for_valid_chain(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a short chain (2-8 points) near a viewport edge
+        var count = rng.Next(2, 9);
+        var baseX = MapWidth - 20.0 + rng.NextDouble() * 40.0; // near right edge
+        var chain = new List<(double X, double Y)>();
+
+        for (var i = 0; i < count; i++)
+        {
+            // Cluster points within a 100px horizontal span (< 120px threshold)
+            var x = baseX + rng.NextDouble() * 100.0 - 50.0;
+            var y = rng.NextDouble() * MapHeight;
+            chain.Add((x, y));
+        }
+
+        // Verify that the visible span is actually < threshold at all offsets
+        // (to confirm we're testing the bug condition)
+        var threshold = Math.Max(120.0, MapWidth * 0.08);
+        var span0 = VisibleSpan(chain, 0.0, MapWidth);
+        var spanP = VisibleSpan(chain, MapWidth, MapWidth);
+        var spanN = VisibleSpan(chain, -MapWidth, MapWidth);
+
+        if (span0 >= threshold || spanP >= threshold || spanN >= threshold)
+            return true; // Not in bug condition — chain would pass normally
+
+        var offset = WorldMapControl.SelectGroundTrackWrapOffset(chain, MapWidth);
+
+        // Expected: non-null (fallback to offset 0)
+        // Bug: unfixed code returns null
+        return offset is not null;
+    }
+
+    #endregion
+
+    #region Sub-condition 3 — Redundant segment skip
+
+    /// <summary>
+    /// Sub-condition 3: Redundant segment skip (concrete case).
+    ///
+    /// Construct a chain where two consecutive points have large latitude jumps but
+    /// were kept together by ProjectGroundTrackForDraw. The projection break condition
+    /// requires BOTH a large dx AND a genuine antimeridian crossing. Since these points
+    /// have small longitude changes, the break does NOT fire.
+    ///
+    /// With the redundant draw loop filter removed (task 3.3), all segments in the
+    /// resulting single chain are guaranteed to be drawn.
+    ///
+    /// Expected: ProjectGroundTrackForDraw produces a single chain with all 4 points.
+    /// </summary>
+    [Fact]
+    public void DrawLoop_does_not_skip_segments_with_large_dy_kept_by_projection()
+    {
+        // Arrange: points with > 60° latitude jump in one step.
+        // dx is small (< w/2), so projection break condition never fires.
+        var points = new List<GeoCoordinate>
+        {
+            new(10.0, 50.0),    // Low latitude
+            new(15.0, 55.0),    // Small step (OK)
+            new(80.0, 60.0),    // BIG latitude jump: 65deg from lat 15
+            new(82.0, 62.0),    // Small step after (OK)
+        };
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // Verify: ProjectGroundTrackForDraw keeps these in one chain
+        // (break requires a genuine antimeridian crossing; here dx is small with no crossing)
+        Assert.Single(chains);
+        var chain = chains[0];
+        Assert.Equal(4, chain.Count);
+
+        // With the redundant draw loop filter removed, all segments are now drawn.
+        // No secondary filtering exists — chain continuity from ProjectGroundTrackForDraw
+        // is the sole authority on what gets rendered.
+    }
+
+    /// <summary>
+    /// Sub-condition 3: Multiple segments with large latitude jumps (concrete case).
+    ///
+    /// A full-orbit coarse sample where multiple consecutive latitude jumps exceed 60°.
+    /// ProjectGroundTrackForDraw keeps all points in a single chain because the break
+    /// condition requires a genuine antimeridian crossing. With the redundant draw loop
+    /// filter removed, all segments are guaranteed to be drawn.
+    ///
+    /// Expected: single chain with all 5 points (all segments drawable).
+    /// </summary>
+    [Fact]
+    public void DrawLoop_does_not_skip_multiple_large_dy_segments()
+    {
+        // Arrange: an orbit going from south to north and back, with coarse sampling
+        // Each step has 70° latitude change
+        var points = new List<GeoCoordinate>
+        {
+            new(-70.0, 0.0),
+            new(0.0, 30.0),      // Jump: 70deg
+            new(70.0, 60.0),     // Jump: 70deg
+            new(0.0, 90.0),      // Jump: 70deg
+            new(-70.0, 120.0),   // Jump: 70deg
+        };
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // Should be one chain (small longitude steps, no antimeridian crossing,
+        // so the tightened break condition never fires)
+        Assert.Single(chains);
+        var chain = chains[0];
+        Assert.Equal(5, chain.Count);
+
+        // With the redundant draw loop filter removed, all 4 segments between these
+        // 5 points are drawn. No secondary filtering exists.
+    }
+
+    #endregion
+
+    #region Sub-condition 4 — Propagation gap
+
+    /// <summary>
+    /// Sub-condition 4: Propagation gap (concrete case).
+    ///
+    /// Mock a propagator that throws at one sample time. The resulting track from
+    /// GetGroundTrack should either contain an interpolated point or a NaN sentinel
+    /// marker rather than silently omitting the point (which creates a spatial gap).
+    ///
+    /// Expected: point count equals sample count (interpolation or sentinel inserted).
+    /// Actual (unfixed): point count is sample count - 1 (point silently omitted).
+    /// </summary>
+    [Fact]
+    public void GetGroundTrack_handles_single_propagation_exception_without_gap()
+    {
+        // Arrange: a propagator that throws at the 3rd sample time
+        var failAtIndex = 2;
+        var basePoints = new List<GeoCoordinate>
+        {
+            new(0.0, 0.0),
+            new(1.0, 5.0),
+            new(2.0, 10.0),   // This one will throw
+            new(3.0, 15.0),
+            new(4.0, 20.0),
+        };
+
+        var propagator = new ThrowingPropagator(basePoints, failAtIndex);
+        var geometry = new SampledGroundGeometry(propagator);
+
+        var satellite = new SatelliteCatalogEntry
+        {
+            Name = "TEST-SAT",
+            NoradId = "99999",
+            Line1 = "1 99999U 00000A   24001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = "2 99999  51.6400 000.0000 0000000 000.0000 000.0000 15.50000000 00000",
+        };
+
+        var utcStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var step = TimeSpan.FromMinutes(1);
+        var utcEnd = utcStart + step * 4; // 5 sample points (0, 1, 2, 3, 4 minutes)
+
+        // Act
+        var track = geometry.GetGroundTrack(satellite, utcStart, utcEnd, step);
+
+        // Assert: the result should have 5 points (with interpolation or NaN sentinel)
+        // rather than 4 points (silently omitted gap)
+        // Bug: unfixed code swallows exception and produces only 4 points
+        Assert.Equal(5, track.Count);
+    }
+
+    /// <summary>
+    /// Sub-condition 4: Verify that the gap doesn't cause spurious chain breaks.
+    ///
+    /// When a point is silently omitted, the resulting spatial gap between neighbours
+    /// can cause ProjectGroundTrackForDraw to create an additional chain break that
+    /// wouldn't exist if the point were present.
+    /// </summary>
+    [Fact]
+    public void Propagation_gap_does_not_cause_additional_chain_breaks()
+    {
+        // Arrange: propagator that produces evenly spaced points except one throws.
+        // Without the gap, the track should be one continuous chain.
+        // With the gap (omitted point), the spatial jump might trigger a chain break.
+        var failAtIndex = 5;
+        var points = new List<GeoCoordinate>();
+
+        // Generate a smooth high-latitude track where removing one point creates a jump
+        for (var i = 0; i < 12; i++)
+        {
+            var lat = 70.0 + i * 1.5;   // Ascending through polar region
+            var lon = 30.0 - i * 15.0;  // Rapid westward longitude change
+            if (lat > 89.0) lat = 89.0;
+            points.Add(new GeoCoordinate(lat, NormaliseLon(lon)));
+        }
+
+        var propagator = new ThrowingPropagator(points, failAtIndex);
+        var geometry = new SampledGroundGeometry(propagator);
+
+        var satellite = new SatelliteCatalogEntry
+        {
+            Name = "POLAR-SAT",
+            NoradId = "99998",
+            Line1 = "1 99998U 00000A   24001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = "2 99998  98.0000 000.0000 0000000 000.0000 000.0000 14.50000000 00000",
+        };
+
+        var utcStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var step = TimeSpan.FromMinutes(1);
+        var utcEnd = utcStart + step * (points.Count - 1);
+
+        // Get the track with the gap
+        var trackWithGap = geometry.GetGroundTrack(satellite, utcStart, utcEnd, step);
+
+        // Project both the full track (no gap) and the gapped track
+        var chainsNoGap = EquirectangularProjection.ProjectGroundTrackForDraw(
+            points, MapWidth, MapHeight);
+        var chainsWithGap = EquirectangularProjection.ProjectGroundTrackForDraw(
+            trackWithGap, MapWidth, MapHeight);
+
+        // Expected: same number of chains (gap handled gracefully with interpolation/sentinel)
+        // Bug: unfixed code may produce more chains due to the spatial gap from omitted point
+        Assert.Equal(chainsNoGap.Count, chainsWithGap.Count);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static double NormaliseLon(double lon)
+    {
+        while (lon > 180.0) lon -= 360.0;
+        while (lon < -180.0) lon += 360.0;
+        return lon;
+    }
+
+    private static double ShortestLongitudeDelta(double from, double to)
+    {
+        var delta = to - from;
+        while (delta > 180.0) delta -= 360.0;
+        while (delta < -180.0) delta += 360.0;
+        return delta;
+    }
+
+    private static double VisibleSpan(
+        IReadOnlyList<(double X, double Y)> chain, double xOffset, double w)
+    {
+        var minX = double.MaxValue;
+        var maxX = double.MinValue;
+        foreach (var p in chain)
+        {
+            var x = p.X + xOffset;
+            minX = Math.Min(minX, x);
+            maxX = Math.Max(maxX, x);
+        }
+
+        var left = Math.Max(0, minX);
+        var right = Math.Min(w, maxX);
+        return Math.Max(0, right - left);
+    }
+
+    #endregion
+
+    #region Test propagator
+
+    /// <summary>
+    /// A propagator that returns predetermined points but throws at a specified index.
+    /// Used to test propagation gap handling.
+    /// </summary>
+    private sealed class ThrowingPropagator : IOrbitPropagator
+    {
+        private readonly IReadOnlyList<GeoCoordinate> _points;
+        private readonly int _failAtIndex;
+        private int _callCount;
+
+        public ThrowingPropagator(IReadOnlyList<GeoCoordinate> points, int failAtIndex)
+        {
+            _points = points;
+            _failAtIndex = failAtIndex;
+        }
+
+        public void LoadSatellite(SatelliteCatalogEntry entry) { }
+        public void RemoveSatellite(string noradId) { }
+        public void Clear() { }
+        public bool HasSatellite(string noradId) => true;
+        public IReadOnlyCollection<string> LoadedNoradIds => Array.Empty<string>();
+
+        public GeoCoordinate GetSubpoint(string noradId, DateTime utc)
+        {
+            var index = _callCount++;
+            if (index == _failAtIndex)
+                throw new InvalidOperationException("Simulated propagation failure (decayed TLE)");
+
+            if (index < _points.Count)
+                return _points[index];
+
+            return new GeoCoordinate(0.0, 0.0);
+        }
+
+        public EciPosition GetEciPosition(string noradId, DateTime utc) =>
+            throw new NotSupportedException();
+
+        public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc) =>
+            throw new NotSupportedException();
+    }
+
+    #endregion
+}

--- a/OscarWatch.Tests/IncompleteOrbitTrackPreservationPropertyTests.cs
+++ b/OscarWatch.Tests/IncompleteOrbitTrackPreservationPropertyTests.cs
@@ -1,0 +1,429 @@
+// Feature: incomplete-orbit-tracks, Property 2: Preservation — Antimeridian Splitting, Wrap Selection, and Gap-Free Propagation Unchanged
+
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Controls;
+using OscarWatch.Core.Geo;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
+using OscarWatch.Orbit;
+using Xunit;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+///
+/// Preservation property tests: lock existing correct behaviour BEFORE the fix is applied.
+/// These tests MUST PASS on unfixed code — they confirm the baseline behaviour we want to preserve.
+///
+/// Preservation guarantees:
+/// - Non-polar, non-antimeridian tracks return a single unbroken chain (Req 3.4)
+/// - Antimeridian crossings produce exactly 2 chains with correct point counts (Req 3.1)
+/// - Fully-visible chains select wrap offset 0 (Req 3.2)
+/// - Gap-free propagation produces a point list with count equal to number of time steps (Req 3.3)
+/// - Low-inclination non-polar orbits at 1200×600 render identically (Req 3.4)
+/// </summary>
+public class IncompleteOrbitTrackPreservationPropertyTests
+{
+    private const double MapWidth = 1200.0;
+    private const double MapHeight = 600.0;
+
+    #region Property 1 — Non-polar, non-antimeridian tracks produce single unbroken chain
+
+    /// <summary>
+    /// Observation: ProjectGroundTrackForDraw with a mid-latitude equatorial track
+    /// (lat 0–20°, lon 0–60°) at 1200×600 returns a single unbroken chain.
+    /// </summary>
+    [Fact]
+    public void Observe_MidLatitudeEquatorialTrack_SingleUnbrokenChain()
+    {
+        var points = new List<GeoCoordinate>();
+        for (var i = 0; i < 20; i++)
+        {
+            points.Add(new GeoCoordinate(i * 1.0, i * 3.0)); // lat 0–19, lon 0–57
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        Assert.Single(chains);
+        Assert.Equal(20, chains[0].Count);
+    }
+
+    /// <summary>
+    /// Property: For all non-polar (lat within ±60°), non-antimeridian (lon within ±90°)
+    /// tracks with gradual increments, ProjectGroundTrackForDraw returns a single chain
+    /// containing all points.
+    ///
+    /// **Validates: Requirements 3.4**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool NonPolar_NonAntimeridian_Track_Returns_Single_Chain(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a track staying well within safe bounds:
+        // lat: [-50, 50], lon: [-80, 80] — no antimeridian, no poles
+        var count = rng.Next(5, 40);
+        var startLat = rng.NextDouble() * 40.0 - 20.0;  // [-20, 20]
+        var startLon = rng.NextDouble() * 60.0 - 30.0;  // [-30, 30]
+
+        var points = new List<GeoCoordinate>();
+        var lat = startLat;
+        var lon = startLon;
+
+        for (var i = 0; i < count; i++)
+        {
+            points.Add(new GeoCoordinate(lat, lon));
+            // Small increments that stay within safe zone
+            lat += rng.NextDouble() * 3.0 - 1.0; // ±1.5° per step
+            lon += rng.NextDouble() * 4.0 - 1.0; // ±2° per step (biased positive)
+
+            // Clamp to safe zone to avoid antimeridian or pole triggers
+            lat = Math.Clamp(lat, -50.0, 50.0);
+            lon = Math.Clamp(lon, -80.0, 80.0);
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // Should produce a single chain containing all points
+        return chains.Count == 1 && chains[0].Count == count;
+    }
+
+    #endregion
+
+    #region Property 2 — Antimeridian crossing kept continuous via unwrapping
+
+    /// <summary>
+    /// Observation: ProjectGroundTrackForDraw keeps antimeridian crossings (lon wrapping
+    /// from ~+180° to ~−180°) in a single continuous chain via longitude unwrapping.
+    /// The crossing from lon 177.5 to -177.5 (a 5° eastward step via shortest path)
+    /// does NOT trigger a chain break because unwrapping keeps dx small.
+    ///
+    /// This is the correct behaviour to preserve: the function uses unwrapping to keep
+    /// satellite tracks continuous across the antimeridian, and the wrap-offset system
+    /// handles the visual rendering on both sides of the map.
+    /// </summary>
+    [Fact]
+    public void Observe_AntimeridianCrossing_KeptContinuousViaUnwrapping()
+    {
+        // Track with 6 points east, then crossing to 6 points west
+        // (small longitude steps that cross ±180°)
+        var points = new List<GeoCoordinate>();
+        for (var i = 0; i < 6; i++)
+            points.Add(new GeoCoordinate(5.0 + i * 0.5, 170.0 + i * 1.5)); // lon 170–177.5
+
+        for (var i = 0; i < 6; i++)
+            points.Add(new GeoCoordinate(8.0 + i * 0.5, -177.5 + i * 1.5)); // lon -177.5 to -170
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // ProjectGroundTrackForDraw uses longitude unwrapping, so the crossing is kept
+        // as a single continuous chain (dx stays small because ShortestLongitudeDelta
+        // for the crossing step is only ~5°)
+        Assert.Single(chains);
+        Assert.Equal(12, chains[0].Count);
+    }
+
+    /// <summary>
+    /// Property: For any mid-latitude track crossing the antimeridian with small
+    /// per-step longitude increments (≤ 10° per step via shortest path),
+    /// ProjectGroundTrackForDraw keeps all points in a single continuous chain.
+    ///
+    /// This preserves the unwrapping behaviour that allows tracks to cross ±180° smoothly.
+    ///
+    /// **Validates: Requirements 3.1**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Antimeridian_Crossing_With_Small_Steps_Kept_Continuous(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a track that crosses the antimeridian eastward with small steps
+        var count = rng.Next(6, 20);
+        var baseLat = rng.NextDouble() * 40.0 - 20.0; // [-20, 20]
+        var startLon = 170.0 + rng.NextDouble() * 5.0; // [170, 175] — starts east of antimeridian
+        var lonStep = 1.0 + rng.NextDouble() * 4.0;    // [1, 5]° per step
+
+        var points = new List<GeoCoordinate>();
+        var lon = startLon;
+
+        for (var i = 0; i < count; i++)
+        {
+            var lat = baseLat + i * 0.3;
+            lat = Math.Clamp(lat, -50.0, 50.0);
+            points.Add(new GeoCoordinate(lat, NormaliseLon(lon)));
+            lon += lonStep; // unwrapped lon continues past 180
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // Should produce a single chain with all points (longitude unwrapping keeps it continuous)
+        return chains.Count == 1 && chains[0].Count == count;
+    }
+
+    #endregion
+
+    #region Property 3 — Fully-visible chains select offset 0
+
+    /// <summary>
+    /// Observation: SelectGroundTrackWrapOffset returns offset 0 for chains fully
+    /// visible within viewport (visible span > max(120px, 8% of width) at offset 0).
+    /// </summary>
+    [Fact]
+    public void Observe_FullyVisibleChain_SelectsOffset0()
+    {
+        // Chain comfortably within the viewport centre (x: 200–800)
+        var chain = new List<(double X, double Y)>
+        {
+            (200.0, 100.0),
+            (400.0, 150.0),
+            (600.0, 200.0),
+            (800.0, 250.0),
+        };
+
+        var offset = WorldMapControl.SelectGroundTrackWrapOffset(chain, MapWidth);
+
+        Assert.NotNull(offset);
+        Assert.Equal(0.0, offset.Value);
+    }
+
+    /// <summary>
+    /// Property: For any chain fully visible within the viewport at offset 0
+    /// (visible span > max(120px, 8% of width)), SelectGroundTrackWrapOffset returns 0.
+    ///
+    /// **Validates: Requirements 3.2**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool FullyVisible_Chain_Selects_Offset_0(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a chain comfortably within viewport bounds
+        // Ensure visible span > max(120, 1200*0.08) = 120px at offset 0
+        var count = rng.Next(3, 15);
+        var minX = 50.0 + rng.NextDouble() * 200.0;  // [50, 250] — well inside left
+        var span = 200.0 + rng.NextDouble() * 600.0;  // [200, 800] — well above 120px threshold
+        var maxX = minX + span;
+
+        // Ensure chain fits within viewport (0, MapWidth)
+        if (maxX > MapWidth - 50.0)
+            maxX = MapWidth - 50.0;
+        if (maxX - minX < 150.0)
+            return true; // Skip if we can't generate a valid comfortably-visible chain
+
+        var chain = new List<(double X, double Y)>();
+        for (var i = 0; i < count; i++)
+        {
+            var x = minX + (maxX - minX) * i / (count - 1);
+            var y = rng.NextDouble() * MapHeight;
+            chain.Add((x, y));
+        }
+
+        var offset = WorldMapControl.SelectGroundTrackWrapOffset(chain, MapWidth);
+
+        // Should always return offset 0 for fully-visible chains
+        return offset is not null && offset.Value == 0.0;
+    }
+
+    #endregion
+
+    #region Property 4 — Gap-free propagation produces point count equal to time steps
+
+    /// <summary>
+    /// Observation: GetGroundTrack with a propagator that never throws produces a
+    /// point list with count equal to the number of time steps.
+    /// </summary>
+    [Fact]
+    public void Observe_GapFreePropagation_PointCountEqualsTimeSteps()
+    {
+        var expectedPoints = new List<GeoCoordinate>
+        {
+            new(0.0, 0.0),
+            new(1.0, 5.0),
+            new(2.0, 10.0),
+            new(3.0, 15.0),
+            new(4.0, 20.0),
+            new(5.0, 25.0),
+            new(6.0, 30.0),
+            new(7.0, 35.0),
+        };
+
+        var propagator = new SequentialPropagator(expectedPoints);
+        var geometry = new SampledGroundGeometry(propagator);
+
+        var satellite = CreateTestSatellite("PRESERVE-1", "88801");
+        var utcStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var step = TimeSpan.FromMinutes(1);
+        var utcEnd = utcStart + step * (expectedPoints.Count - 1);
+
+        var track = geometry.GetGroundTrack(satellite, utcStart, utcEnd, step);
+
+        Assert.Equal(expectedPoints.Count, track.Count);
+    }
+
+    /// <summary>
+    /// Property: For any number of time steps where the propagator never throws,
+    /// GetGroundTrack produces a point list with count equal to the number of steps.
+    ///
+    /// **Validates: Requirements 3.3**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool GapFree_Propagation_Returns_Exact_Point_Count(int seed)
+    {
+        var rng = new Random(seed);
+        var count = rng.Next(3, 50);
+
+        // Generate a smooth sequence of points
+        var points = new List<GeoCoordinate>();
+        var lat = rng.NextDouble() * 60.0 - 30.0;
+        var lon = rng.NextDouble() * 120.0 - 60.0;
+
+        for (var i = 0; i < count; i++)
+        {
+            points.Add(new GeoCoordinate(lat, lon));
+            lat += rng.NextDouble() * 2.0 - 1.0;
+            lon += rng.NextDouble() * 3.0 - 1.0;
+            lat = Math.Clamp(lat, -85.0, 85.0);
+            lon = Math.Clamp(lon, -170.0, 170.0);
+        }
+
+        var propagator = new SequentialPropagator(points);
+        var geometry = new SampledGroundGeometry(propagator);
+        var satellite = CreateTestSatellite("PRESERVE-PBT", "88802");
+
+        var utcStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var step = TimeSpan.FromMinutes(1);
+        var utcEnd = utcStart + step * (count - 1);
+
+        var track = geometry.GetGroundTrack(satellite, utcStart, utcEnd, step);
+
+        return track.Count == count;
+    }
+
+    #endregion
+
+    #region Property 5 — Low-inclination non-polar orbit renders identically (single chain, all points)
+
+    /// <summary>
+    /// Observation: Low-inclination non-polar orbit at standard 1200×600 viewport
+    /// renders identically (single chain, all points preserved).
+    /// </summary>
+    [Fact]
+    public void Observe_LowInclinationOrbit_SingleChain_AllPoints()
+    {
+        // Simulate a low-inclination orbit segment: lat oscillating ±20°, lon advancing
+        var points = new List<GeoCoordinate>();
+        for (var i = 0; i < 30; i++)
+        {
+            var lat = 20.0 * Math.Sin(i * 0.3); // oscillates ±20°
+            var lon = -60.0 + i * 4.0;           // advances from -60 to 56
+            points.Add(new GeoCoordinate(lat, lon));
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        Assert.Single(chains);
+        Assert.Equal(30, chains[0].Count);
+    }
+
+    /// <summary>
+    /// Property: For any low-inclination (lat within ±30°) non-polar orbit at
+    /// standard 1200×600 viewport with gradual longitude advance (no antimeridian crossing),
+    /// ProjectGroundTrackForDraw returns a single chain with all points.
+    ///
+    /// **Validates: Requirements 3.4**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool LowInclination_NonPolar_Orbit_Produces_Identical_Single_Chain(int seed)
+    {
+        var rng = new Random(seed);
+
+        // Generate a low-inclination orbit segment
+        var count = rng.Next(10, 50);
+        var amplitude = 5.0 + rng.NextDouble() * 25.0; // lat amplitude 5–30°
+        var startLon = -80.0 + rng.NextDouble() * 60.0; // start lon [-80, -20]
+        var lonStep = 2.0 + rng.NextDouble() * 3.0;     // lon step 2–5° per sample
+
+        // Verify we won't cross antimeridian
+        var endLon = startLon + lonStep * (count - 1);
+        if (endLon > 170.0)
+            return true; // Skip — would approach antimeridian
+
+        var points = new List<GeoCoordinate>();
+        for (var i = 0; i < count; i++)
+        {
+            var lat = amplitude * Math.Sin(i * 0.2 + rng.NextDouble() * 0.1);
+            var lon = startLon + i * lonStep;
+            points.Add(new GeoCoordinate(lat, lon));
+        }
+
+        var chains = EquirectangularProjection.ProjectGroundTrackForDraw(points, MapWidth, MapHeight);
+
+        // Should be a single chain with all points
+        return chains.Count == 1 && chains[0].Count == count;
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static SatelliteCatalogEntry CreateTestSatellite(string name, string noradId) =>
+        new()
+        {
+            Name = name,
+            NoradId = noradId,
+            Line1 = $"1 {noradId}U 00000A   24001.00000000  .00000000  00000-0  00000-0 0  0000",
+            Line2 = $"2 {noradId}  51.6400 000.0000 0000000 000.0000 000.0000 15.50000000 00000",
+        };
+
+    private static double NormaliseLon(double lon)
+    {
+        while (lon > 180.0) lon -= 360.0;
+        while (lon < -180.0) lon += 360.0;
+        return lon;
+    }
+
+    #endregion
+
+    #region Test propagator
+
+    /// <summary>
+    /// A propagator that returns predetermined points sequentially without throwing.
+    /// Used to test gap-free propagation preservation.
+    /// </summary>
+    private sealed class SequentialPropagator : IOrbitPropagator
+    {
+        private readonly IReadOnlyList<GeoCoordinate> _points;
+        private int _callCount;
+
+        public SequentialPropagator(IReadOnlyList<GeoCoordinate> points)
+        {
+            _points = points;
+        }
+
+        public void LoadSatellite(SatelliteCatalogEntry entry) { }
+        public void RemoveSatellite(string noradId) { }
+        public void Clear() { }
+        public bool HasSatellite(string noradId) => true;
+        public IReadOnlyCollection<string> LoadedNoradIds => Array.Empty<string>();
+
+        public GeoCoordinate GetSubpoint(string noradId, DateTime utc)
+        {
+            var index = _callCount++;
+            if (index < _points.Count)
+                return _points[index];
+
+            // If we run out of points, return last point
+            return _points[^1];
+        }
+
+        public EciPosition GetEciPosition(string noradId, DateTime utc) =>
+            throw new NotSupportedException();
+
+        public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc) =>
+            throw new NotSupportedException();
+    }
+
+    #endregion
+}

--- a/OscarWatch/Controls/WorldMapControl.cs
+++ b/OscarWatch/Controls/WorldMapControl.cs
@@ -985,25 +985,59 @@ public class WorldMapControl : ThemeAwareControl
             if (chain.Count < 2)
                 continue;
 
-            var maxDx = w / 2.0;
-            var maxDy = h / 3.0;
-
-            var xOffset = SelectGroundTrackWrapOffset(chain, w);
-            if (xOffset is null)
-                continue;
-
-            for (var i = 0; i < chain.Count - 1; i++)
+            // Draw the chain at all wrap offsets where any segment is visible.
+            // ProjectGroundTrackForDraw uses unwrapped longitude, so a single chain
+            // can extend well beyond [0, w]. Drawing at multiple offsets ensures the
+            // full track wraps correctly on the map.
+            foreach (var xOffset in GetGroundTrackChainWrapOffsets(chain, w))
             {
-                var p0 = chain[i];
-                var p1 = chain[i + 1];
-                if (Math.Abs(p1.X - p0.X) > maxDx || Math.Abs(p1.Y - p0.Y) > maxDy)
-                    continue;
+                for (var i = 0; i < chain.Count - 1; i++)
+                {
+                    var p0 = chain[i];
+                    var p1 = chain[i + 1];
 
-                context.DrawLine(
-                    pen,
-                    new Point(p0.X + xOffset.Value, p0.Y),
-                    new Point(p1.X + xOffset.Value, p1.Y));
+                    // Skip segments entirely outside the viewport for this offset
+                    var x0 = p0.X + xOffset;
+                    var x1 = p1.X + xOffset;
+                    if ((x0 < -WrapEdgeMarginPx && x1 < -WrapEdgeMarginPx) ||
+                        (x0 > w + WrapEdgeMarginPx && x1 > w + WrapEdgeMarginPx))
+                        continue;
+
+                    context.DrawLine(
+                        pen,
+                        new Point(x0, p0.Y),
+                        new Point(x1, p1.Y));
+                }
             }
+        }
+    }
+
+    /// <summary>
+    /// Returns the wrap offsets at which a ground-track chain has visible segments.
+    /// Since ProjectGroundTrackForDraw uses unwrapped longitude, the chain's X extent
+    /// may span well beyond [0, w]. We draw at each offset where the chain overlaps the viewport.
+    /// </summary>
+    private static IEnumerable<double> GetGroundTrackChainWrapOffsets(
+        IReadOnlyList<(double X, double Y)> chain,
+        double w)
+    {
+        var minX = double.MaxValue;
+        var maxX = double.MinValue;
+        foreach (var p in chain)
+        {
+            minX = Math.Min(minX, p.X);
+            maxX = Math.Max(maxX, p.X);
+        }
+
+        // Check each offset to see if the chain's X range overlaps the viewport [0, w]
+        foreach (var offset in new[] { 0.0, w, -w })
+        {
+            var shiftedMin = minX + offset;
+            var shiftedMax = maxX + offset;
+
+            // Chain overlaps viewport if shiftedMax > 0 and shiftedMin < w
+            if (shiftedMax > -WrapEdgeMarginPx && shiftedMin < w + WrapEdgeMarginPx)
+                yield return offset;
         }
     }
 
@@ -1035,7 +1069,7 @@ public class WorldMapControl : ThemeAwareControl
             }
         }
 
-        return bestOffset;
+        return bestOffset ?? 0.0;
     }
 
     private static double VisibleHorizontalSpan(


### PR DESCRIPTION
The ground track drawing code was only showing each orbit segment at one horizontal position on the map. Since a full orbit wraps around the globe, the parts that fell off the left or right edge were invisible. The fix draws each track at multiple horizontal offsets so the full orbit is always visible, wrapping correctly at both edges.