### PR TITLE
Fix Doppler rate-of-change near TCA exceeding radio response

### DIFF
--- a/OscarWatch.Core/Radio/DopplerCatLead.cs
+++ b/OscarWatch.Core/Radio/DopplerCatLead.cs
@@ -172,7 +172,7 @@ public static class DopplerCatLead
         return RecedingAssistMaxBlend * rateFactor * slopeFactor;
     }
 
-    internal static double ComputeRangeRateSlopeKmPerSec2(
+    public static double ComputeRangeRateSlopeKmPerSec2(
         IOrbitPropagator propagator,
         string noradId,
         GroundStation site,

--- a/OscarWatch.Core/Radio/DopplerWritePacer.cs
+++ b/OscarWatch.Core/Radio/DopplerWritePacer.cs
@@ -1,0 +1,74 @@
+namespace OscarWatch.Core.Radio;
+
+/// <summary>
+/// Adaptive rate-limiting for Doppler CAT writes near TCA.
+/// Below SlopeBlendStartKmPerSec2, all methods are no-ops (preserving existing behaviour).
+/// </summary>
+public static class DopplerWritePacer
+{
+    public const int PostCatWriteDialSettleMs = 350;
+
+    /// <summary>
+    /// Determines whether a CAT write should be deferred based on Doppler acceleration,
+    /// radio settle time, and direction-change state.
+    /// </summary>
+    /// <param name="slopeKmPerSec2">Current range-rate slope (km/s²).</param>
+    /// <param name="catDelayMs">Operator-configured inter-command spacing (ms).</param>
+    /// <param name="timeSinceLastWriteMs">Elapsed time since the previous CAT write (ms).</param>
+    /// <param name="dopplerReversed">True if Doppler direction has reversed since last write.</param>
+    /// <returns>True if the write should be deferred (suppressed this iteration).</returns>
+    public static bool ShouldDeferWrite(double slopeKmPerSec2, int catDelayMs, double timeSinceLastWriteMs, bool dopplerReversed)
+    {
+        // Below the blend start threshold, never defer — preserves existing behaviour
+        if (slopeKmPerSec2 < DopplerCatLead.SlopeBlendStartKmPerSec2)
+            return false;
+
+        double adaptiveMinInterval;
+
+        if (dopplerReversed)
+        {
+            // On Doppler reversal, enforce the FULL settle window regardless of blend
+            adaptiveMinInterval = catDelayMs + PostCatWriteDialSettleMs;
+        }
+        else
+        {
+            // Compute blend factor: ramps 0→1 over [SlopeBlendStartKmPerSec2, SteepRangeRateSlopeKmPerSec2]
+            var blendFactor = ComputeBlendFactor(slopeKmPerSec2);
+            adaptiveMinInterval = catDelayMs + PostCatWriteDialSettleMs * blendFactor;
+        }
+
+        return timeSinceLastWriteMs < adaptiveMinInterval;
+    }
+
+    /// <summary>
+    /// Computes an adaptive frequency-change threshold that widens on steep Doppler legs,
+    /// reducing the number of writes that pass the ShouldWrite gate.
+    /// </summary>
+    /// <param name="baseThresholdHz">The base threshold (e.g. 50 Hz linear, 350 Hz FM).</param>
+    /// <param name="slopeKmPerSec2">Current range-rate slope (km/s²).</param>
+    /// <returns>The adaptive threshold (Hz), ranging from 1× to 3× the base.</returns>
+    public static int AdaptiveThresholdHz(int baseThresholdHz, double slopeKmPerSec2)
+    {
+        // Below the blend start threshold, return base unchanged — preserves existing behaviour
+        if (slopeKmPerSec2 < DopplerCatLead.SlopeBlendStartKmPerSec2)
+            return baseThresholdHz;
+
+        // Compute blend factor: ramps 0→1 over [SlopeBlendStartKmPerSec2, SteepRangeRateSlopeKmPerSec2]
+        var blendFactor = ComputeBlendFactor(slopeKmPerSec2);
+
+        // Ramp from 1× to 3× base threshold (adding up to 2× base at full blend)
+        return baseThresholdHz + (int)(baseThresholdHz * 2 * blendFactor);
+    }
+
+    /// <summary>
+    /// Computes the blend factor (0→1) over the slope ramp range, clamped at 1.0.
+    /// </summary>
+    private static double ComputeBlendFactor(double slopeKmPerSec2)
+    {
+        if (slopeKmPerSec2 >= DopplerCatLead.SteepRangeRateSlopeKmPerSec2)
+            return 1.0;
+
+        return (slopeKmPerSec2 - DopplerCatLead.SlopeBlendStartKmPerSec2)
+            / (DopplerCatLead.SteepRangeRateSlopeKmPerSec2 - DopplerCatLead.SlopeBlendStartKmPerSec2);
+    }
+}

--- a/OscarWatch.Tests/DopplerTcaRateLimitBugConditionPropertyTests.cs
+++ b/OscarWatch.Tests/DopplerTcaRateLimitBugConditionPropertyTests.cs
@@ -1,0 +1,351 @@
+// Feature: doppler-tca-rate-limit, Property 1: Bug Condition — High-Acceleration Writes Outpace Radio Settle Time
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Orbit;
+using OscarWatch.Core.Radio;
+using OscarWatch.Rig;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 1.1, 1.2, 1.3**
+///
+/// Bug condition exploration test: demonstrates that during high Doppler acceleration
+/// (near TCA), the system issues CAT writes faster than the radio can settle.
+///
+/// The current <c>ShouldWrite</c> logic returns true every 100ms loop iteration when
+/// frequency delta exceeds threshold (50 Hz linear) — which happens every iteration on
+/// high-slope passes. The radio needs <c>catDelayMs + PostCatWriteDialSettleMs</c> (≈400 ms)
+/// to settle, yet writes fire every 100 ms.
+///
+/// This test is EXPECTED TO FAIL on unfixed code — failure confirms the bug exists.
+/// After the fix (DopplerWritePacer), these tests will pass.
+/// </summary>
+public class DopplerTcaRateLimitBugConditionPropertyTests
+{
+    /// <summary>
+    /// The radio's dial-settle window after a CAT write (from RigController.PostCatWriteDialSettleMs).
+    /// </summary>
+    private const int PostCatWriteDialSettleMs = 350;
+
+    /// <summary>
+    /// Bug Condition — High-Slope Continuous Writes
+    ///
+    /// With slope = 0.018 km/s² (well above SlopeBlendStartKmPerSec2 = 0.010) and
+    /// CatDelayMs = 50 ms, the current code fires writes every time the frequency delta
+    /// exceeds the 50 Hz threshold — which with a fast-changing Doppler happens much faster
+    /// than the radio's settle time of catDelayMs + PostCatWriteDialSettleMs (≈400 ms).
+    ///
+    /// Expected behaviour: writes should be deferred until at least
+    /// <c>catDelayMs + PostCatWriteDialSettleMs × blendFactor</c> (≈400 ms) has elapsed.
+    ///
+    /// Actual (unfixed): writes fire as soon as CatDelayMs (50ms) has elapsed and the
+    /// frequency delta exceeds threshold — no awareness of the radio settle window.
+    ///
+    /// To reliably demonstrate the bug, we use a large range rate shift between iterations
+    /// (simulating the led+slope scenario where the target frequency jumps significantly
+    /// each loop) so the 50 Hz threshold is exceeded every iteration.
+    /// </summary>
+    [Fact]
+    public void High_slope_writes_should_not_fire_faster_than_radio_settle_time()
+    {
+        // Arrange: Use a scenario where each iteration produces a large enough frequency
+        // change to exceed the 50 Hz threshold. This simulates what happens near TCA:
+        // the led frequency shifts rapidly because the propagator-predicted rate changes
+        // significantly within the loop interval.
+        //
+        // At 435 MHz, 50 Hz threshold corresponds to ΔrangeRate ≈ 50 / (435850/299792) ≈ 0.034 km/s
+        // So we need at least 0.035 km/s change per iteration to guarantee threshold crossing.
+        // With slope = 0.018 km/s², lead enabled and high base rate, the target shifts ~150 Hz/iteration.
+        const double initialRangeRate = -5.0; // km/s — high base rate for large absolute shifts
+        const double slopeKmPerSec2 = 0.018;
+        const int catDelayMs = 50;
+
+        // Each iteration shifts range rate by 0.05 km/s (simulating 500ms of slope × iteration,
+        // representing the cumulative shift the lead predictor sees). This produces ~73 Hz delta
+        // per iteration on a 435 MHz downlink, exceeding the 50 Hz threshold every time.
+        const double rangeRateShiftPerIteration = 0.05;
+
+        var propagator = new SteepSlopePropagator(initialRangeRate, initialRangeRate + slopeKmPerSec2);
+        var rig = new RecordingRigDriver();
+        var controller = new RigController(_ => rig, propagator: propagator);
+
+        var settings = new RigSettings
+        {
+            Enabled = true,
+            Type = RigType.Dummy,
+            DopplerThresholdLinearHz = 50,
+            DopplerCatLeadEnabled = true,
+            CatDelayMs = catDelayMs
+        };
+
+        var mode = new SatelliteTransponderMode
+        {
+            DownlinkKHz = 435_850.45,
+            UplinkKHz = 145_952.65,
+            DownlinkMode = "USB",
+            UplinkMode = "LSB",
+            Doppler = "REV"
+        };
+
+        var state = new SatelliteTrackState
+        {
+            Name = "FO-29",
+            NoradId = "99999",
+            Subpoint = new GeoCoordinate(0, 0, 400),
+            LookAngles = new LookAngles(180, 85, 400, initialRangeRate)
+        };
+
+        var ctx = new RigTrackingContext
+        {
+            TrackState = state,
+            Mode = mode,
+            Corrected = DopplerFrequencyCalculator.Compute(mode, initialRangeRate, 0),
+            TransmitOffsetKHz = 0,
+            ReceiveOffsetKHz = 0
+        };
+
+        // Act: initialise — first Update triggers a write
+        controller.Update(settings, ctx);
+        controller.DrainCommandQueueForTests();
+
+        var writesAfterInit = rig.SetFrequencyCallCount;
+
+        // Simulate rapid loop iterations with changing range rates.
+        var currentRangeRate = initialRangeRate;
+        const int iterations = 10; // ~600ms total (10 × 60ms sleeps)
+
+        for (var i = 0; i < iterations; i++)
+        {
+            // Advance the range rate to simulate rapid Doppler change near TCA
+            currentRangeRate += rangeRateShiftPerIteration;
+
+            // Update look angles and propagator with the new rate
+            propagator.SnapshotRate = currentRangeRate;
+            propagator.FutureRate = currentRangeRate + slopeKmPerSec2;
+
+            state = new SatelliteTrackState
+            {
+                Name = "FO-29",
+                NoradId = "99999",
+                Subpoint = new GeoCoordinate(0, 0, 400),
+                LookAngles = new LookAngles(180, 85, 400, currentRangeRate)
+            };
+
+            ctx = new RigTrackingContext
+            {
+                TrackState = state,
+                Mode = mode,
+                Corrected = DopplerFrequencyCalculator.Compute(mode, currentRangeRate, 0),
+                TransmitOffsetKHz = 0,
+                ReceiveOffsetKHz = 0
+            };
+
+            // Wait just enough to clear the CatDelayMs gate (50ms)
+            // but NOT enough for the full settle time (400ms)
+            Thread.Sleep(catDelayMs + 10); // 60ms — past CatDelayMs but well within settle time
+
+            controller.Update(settings, ctx);
+            controller.DrainCommandQueueForTests();
+        }
+
+        // Total elapsed ≈ 10 × 60ms = 600ms
+        // Assert: The EXPECTED behaviour is that writes should NOT fire faster than
+        // catDelayMs + PostCatWriteDialSettleMs × blendFactor.
+        // With slope 0.018 (above SteepRangeRateSlopeKmPerSec2), blendFactor = 1.0,
+        // so minimum interval = catDelayMs + PostCatWriteDialSettleMs = 50 + 350 = 400 ms.
+        //
+        // Over ~600ms with 400ms minimum interval, we expect at most 1 additional write.
+        // Bug: unfixed code writes on nearly every iteration because CatDelayMs (50ms) has
+        // elapsed and the frequency delta exceeds 50 Hz.
+        var totalPhysicalWrites = rig.SetFrequencyCallCount - writesAfterInit;
+        // Each logical Doppler write cycle writes BOTH RX and TX (full-duplex transponder),
+        // so SetFrequencyCallCount increments by 2 per cycle.
+        var totalDopplerCycles = totalPhysicalWrites / 2;
+        const int expectedMaxCycles = 1; // 600ms / 400ms minimum interval = 1.5, so max 1 cycle
+
+        Assert.True(totalDopplerCycles <= expectedMaxCycles,
+            $"Bug confirmed: {totalDopplerCycles} Doppler write cycle(s) ({totalPhysicalWrites} physical writes) in ~600 ms with slope=0.018 km/s². " +
+            $"Expected at most {expectedMaxCycles} cycle(s) (one per {catDelayMs + PostCatWriteDialSettleMs} ms settle window). " +
+            $"The radio cannot keep up — commands are queuing.");
+    }
+
+    /// <summary>
+    /// Bug Condition — Doppler Reversal Overshoot
+    ///
+    /// When range-rate crosses zero (sign change) with high slope, the current code fires
+    /// a direction-reversed write immediately (within 100ms of the prior write), without
+    /// waiting for the radio to settle.
+    ///
+    /// Expected behaviour: on reversal, a full settle window
+    /// (<c>catDelayMs + PostCatWriteDialSettleMs</c>) should be enforced before the next write.
+    ///
+    /// Actual (unfixed): the reversed write fires as soon as CatDelayMs (50ms) has elapsed.
+    /// </summary>
+    [Fact]
+    public void Doppler_reversal_should_enforce_full_settle_before_next_write()
+    {
+        const double slopeKmPerSec2 = 0.015;
+        const int catDelayMs = 50;
+        const double preReversalRate = -0.05; // approaching — just before zero crossing
+        const double postReversalRate = 0.05;  // receding — just after zero crossing
+
+        var propagator = new SteepSlopePropagator(preReversalRate, preReversalRate + slopeKmPerSec2);
+        var rig = new RecordingRigDriver();
+        var controller = new RigController(_ => rig, propagator: propagator);
+
+        var settings = new RigSettings
+        {
+            Enabled = true,
+            Type = RigType.Dummy,
+            DopplerThresholdLinearHz = 50,
+            DopplerCatLeadEnabled = true,
+            CatDelayMs = catDelayMs
+        };
+
+        var mode = new SatelliteTransponderMode
+        {
+            DownlinkKHz = 435_850.45,
+            UplinkKHz = 145_952.65,
+            DownlinkMode = "USB",
+            UplinkMode = "LSB",
+            Doppler = "REV"
+        };
+
+        // Start with a negative range rate (approaching)
+        var state = new SatelliteTrackState
+        {
+            Name = "FO-29",
+            NoradId = "99999",
+            Subpoint = new GeoCoordinate(0, 0, 400),
+            LookAngles = new LookAngles(180, 88, 400, preReversalRate)
+        };
+
+        var ctx = new RigTrackingContext
+        {
+            TrackState = state,
+            Mode = mode,
+            Corrected = DopplerFrequencyCalculator.Compute(mode, preReversalRate, 0),
+            TransmitOffsetKHz = 0,
+            ReceiveOffsetKHz = 0
+        };
+
+        // Initialise: first write at pre-reversal frequency
+        controller.Update(settings, ctx);
+        controller.DrainCommandQueueForTests();
+
+        var writesBeforeReversal = rig.SetFrequencyCallCount;
+
+        // Wait just enough to clear CatDelayMs but NOT the full settle time
+        Thread.Sleep(catDelayMs + 10); // 60ms — within the 400ms settle window
+
+        // Now reverse direction: range rate crosses zero to positive (receding)
+        propagator.SnapshotRate = postReversalRate;
+        propagator.FutureRate = postReversalRate + slopeKmPerSec2;
+
+        state = new SatelliteTrackState
+        {
+            Name = "FO-29",
+            NoradId = "99999",
+            Subpoint = new GeoCoordinate(0, 0, 400),
+            LookAngles = new LookAngles(180, 88, 400, postReversalRate)
+        };
+
+        ctx = new RigTrackingContext
+        {
+            TrackState = state,
+            Mode = mode,
+            Corrected = DopplerFrequencyCalculator.Compute(mode, postReversalRate, 0),
+            TransmitOffsetKHz = 0,
+            ReceiveOffsetKHz = 0
+        };
+
+        controller.Update(settings, ctx);
+        controller.DrainCommandQueueForTests();
+
+        var writesAfterReversal = rig.SetFrequencyCallCount - writesBeforeReversal;
+
+        // Assert: On reversal with high slope, the EXPECTED behaviour is that the system
+        // waits a full settle window (catDelayMs + PostCatWriteDialSettleMs = 400 ms)
+        // before issuing the reversed-direction write.
+        //
+        // Since only 60ms has elapsed since the last write, no write should occur yet.
+        // Bug: unfixed code writes immediately after CatDelayMs (50ms), ignoring settle needs.
+        Assert.Equal(0, writesAfterReversal);
+    }
+
+    /// <summary>
+    /// Property 1: Bug Condition (Property-Based) — High Slope Causes Write Deferral
+    ///
+    /// For any slope ≥ SlopeBlendStartKmPerSec2 (0.010 km/s²) with CatDelayMs between
+    /// 20–100 ms, DopplerWritePacer.ShouldDeferWrite returns true when
+    /// timeSinceLastWrite &lt; adaptiveMinInterval (catDelayMs + PostCatWriteDialSettleMs × blendFactor).
+    ///
+    /// This property tests the pure pacer logic directly, avoiding Thread.Sleep timing sensitivity.
+    /// The companion Fact tests above exercise the full integration path.
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool High_slope_write_interval_respects_radio_settle_time(int rawSlope, int rawCatDelay, int rawTimeFraction)
+    {
+        // Constrain inputs to the bug condition domain
+        // slope ≥ 0.010 km/s² (SlopeBlendStartKmPerSec2)
+        var slopeKmPerSec2 = 0.010 + Math.Abs(rawSlope % 10) * 0.001; // 0.010 to 0.019
+        var catDelayMs = 20 + Math.Abs(rawCatDelay % 81); // 20 to 100
+
+        // Compute blend factor for this slope (same formula as the pacer)
+        var blendFactor = slopeKmPerSec2 >= DopplerCatLead.SteepRangeRateSlopeKmPerSec2
+            ? 1.0
+            : (slopeKmPerSec2 - DopplerCatLead.SlopeBlendStartKmPerSec2)
+              / (DopplerCatLead.SteepRangeRateSlopeKmPerSec2 - DopplerCatLead.SlopeBlendStartKmPerSec2);
+
+        // Expected minimum interval between writes
+        var expectedMinIntervalMs = catDelayMs + (int)(PostCatWriteDialSettleMs * blendFactor);
+
+        // Generate a time since last write that is WITHIN the settle window
+        // (0 to expectedMinIntervalMs - 1). This simulates the bug condition:
+        // the radio hasn't settled yet, but a write would be attempted.
+        var timeSinceLastWriteMs = (double)(Math.Abs(rawTimeFraction) % Math.Max(1, expectedMinIntervalMs));
+
+        // Property: ShouldDeferWrite MUST return true (defer) when the elapsed time
+        // is less than the adaptive minimum interval. This prevents radio queuing.
+        var shouldDefer = DopplerWritePacer.ShouldDeferWrite(
+            slopeKmPerSec2, catDelayMs, timeSinceLastWriteMs, dopplerReversed: false);
+
+        return shouldDefer;
+    }
+
+    /// <summary>
+    /// Propagator stub that produces a configurable steep slope.
+    /// Returns <see cref="FutureRate"/> for any future time lookup (simulating slope),
+    /// and <see cref="SnapshotRate"/> as the baseline.
+    /// </summary>
+    private sealed class SteepSlopePropagator : IOrbitPropagator
+    {
+        public double SnapshotRate { get; set; }
+        public double FutureRate { get; set; }
+
+        public SteepSlopePropagator(double snapshotRate, double futureRate)
+        {
+            SnapshotRate = snapshotRate;
+            FutureRate = futureRate;
+        }
+
+        public void Clear() { }
+        public void LoadSatellite(SatelliteCatalogEntry entry) { }
+        public void RemoveSatellite(string noradId) { }
+        public GeoCoordinate GetSubpoint(string noradId, DateTime utc) => new(0, 0, 400);
+        public EciPosition GetEciPosition(string noradId, DateTime utc) => new(0, 0, 0);
+        public bool HasSatellite(string noradId) => true;
+        public IReadOnlyCollection<string> LoadedNoradIds => ["99999"];
+
+        public LookAngles GetLookAngles(string noradId, GroundStation site, DateTime utc)
+        {
+            // DopplerCatLead.ComputeRangeRateSlopeKmPerSec2 calls GetLookAngles with
+            // utc + RangeRateSlopeSampleSec (1.0s ahead). Return FutureRate for that.
+            // DopplerCatLead.ResolveRangeRates also calls for lead time (half CatDelayMs ahead).
+            // Both cases use FutureRate to produce a steep slope.
+            return new LookAngles(180, 85, 400, FutureRate);
+        }
+    }
+}

--- a/OscarWatch.Tests/DopplerTcaRateLimitPreservationPropertyTests.cs
+++ b/OscarWatch.Tests/DopplerTcaRateLimitPreservationPropertyTests.cs
@@ -1,0 +1,212 @@
+// Feature: doppler-tca-rate-limit, Property 2: Preservation — Low-Acceleration Tracking Unchanged
+
+using FsCheck.Xunit;
+using OscarWatch.Core.Radio;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+///
+/// Preservation property tests: verify that for all inputs where the Doppler acceleration
+/// (range-rate slope) is below <c>SlopeBlendStartKmPerSec2</c> (0.010 km/s²), the
+/// <see cref="DopplerWritePacer"/> does not interfere with normal tracking behaviour.
+///
+/// These tests MUST PASS on unfixed (stub) code AND continue to pass after the full
+/// implementation — the adaptive logic is gated on slope ≥ 0.010 km/s², so low-slope
+/// inputs remain completely unaffected.
+/// </summary>
+public class DopplerTcaRateLimitPreservationPropertyTests
+{
+    /// <summary>
+    /// The slope threshold below which all adaptive logic is dormant.
+    /// Matches <see cref="DopplerCatLead.SlopeBlendStartKmPerSec2"/>.
+    /// </summary>
+    private const double SlopeBlendStartKmPerSec2 = 0.010;
+
+    // ─── Property-Based Tests ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Property 2a: ShouldDeferWrite returns false for all slope values below 0.010 km/s²
+    /// regardless of timing and direction state.
+    ///
+    /// For any (slope &lt; 0.010, catDelay, timeSinceLastWrite, dopplerReversed) tuple,
+    /// the pacer never defers a write — preserving the existing 100 ms cadence.
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool ShouldDeferWrite_returns_false_for_all_low_slope_inputs(
+        int rawSlope, int rawCatDelay, int rawTimeSinceWrite, bool dopplerReversed)
+    {
+        // Constrain slope to [0, 0.010) km/s² — the low-acceleration domain
+        var slopeKmPerSec2 = Math.Abs(rawSlope % 10000) * 0.000001; // 0.0 to 0.009999
+        if (slopeKmPerSec2 >= SlopeBlendStartKmPerSec2)
+            slopeKmPerSec2 = SlopeBlendStartKmPerSec2 - 0.000001;
+
+        // catDelayMs: 0 to 200 ms (covers typical operator configurations)
+        var catDelayMs = Math.Abs(rawCatDelay % 201);
+
+        // timeSinceLastWriteMs: 0 to 1000 ms (covers all relevant timing windows)
+        var timeSinceLastWriteMs = (double)Math.Abs(rawTimeSinceWrite % 1001);
+
+        var result = DopplerWritePacer.ShouldDeferWrite(
+            slopeKmPerSec2, catDelayMs, timeSinceLastWriteMs, dopplerReversed);
+
+        // Low slope → never defer, regardless of timing or direction state
+        return result == false;
+    }
+
+    /// <summary>
+    /// Property 2b: AdaptiveThresholdHz returns the base threshold unchanged for all
+    /// slope values below 0.010 km/s².
+    ///
+    /// For any (baseThreshold, slope &lt; 0.010) pair, the adaptive threshold equals
+    /// the base threshold — no widening occurs on gentle passes.
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool AdaptiveThresholdHz_returns_base_unchanged_for_all_low_slope_inputs(
+        int rawBaseThreshold, int rawSlope)
+    {
+        // baseThresholdHz: 1 to 500 Hz (covers 50 Hz linear, 350 Hz FM, and beyond)
+        var baseThresholdHz = Math.Abs(rawBaseThreshold % 500) + 1;
+
+        // Constrain slope to [0, 0.010) km/s²
+        var slopeKmPerSec2 = Math.Abs(rawSlope % 10000) * 0.000001; // 0.0 to 0.009999
+        if (slopeKmPerSec2 >= SlopeBlendStartKmPerSec2)
+            slopeKmPerSec2 = SlopeBlendStartKmPerSec2 - 0.000001;
+
+        var result = DopplerWritePacer.AdaptiveThresholdHz(baseThresholdHz, slopeKmPerSec2);
+
+        // Low slope → threshold unchanged
+        return result == baseThresholdHz;
+    }
+
+    /// <summary>
+    /// Property 2c: Low-slope scenarios produce normal write cadence — the pacer
+    /// doesn't interfere regardless of how rapidly writes are attempted.
+    ///
+    /// Simulates a sequence of write-decision checks at various timings (including
+    /// very rapid ones within the settle window) and confirms the pacer never blocks
+    /// any of them when slope is below the threshold.
+    ///
+    /// **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+    /// </summary>
+    [Property(MaxTest = 100)]
+    public bool Low_slope_write_cadence_is_never_throttled(
+        int rawSlope, int rawCatDelay, int rawIterations)
+    {
+        // Low slope: [0, 0.010)
+        var slopeKmPerSec2 = Math.Abs(rawSlope % 10000) * 0.000001;
+        if (slopeKmPerSec2 >= SlopeBlendStartKmPerSec2)
+            slopeKmPerSec2 = SlopeBlendStartKmPerSec2 - 0.000001;
+
+        var catDelayMs = Math.Abs(rawCatDelay % 201);
+
+        // Simulate 1 to 20 rapid write-decision checks at various timings
+        var iterations = Math.Abs(rawIterations % 20) + 1;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            // Vary timing: some within settle window, some outside
+            var timeSinceLastWriteMs = (double)(i * 50); // 0ms, 50ms, 100ms, ...
+            var dopplerReversed = i % 3 == 0; // alternate reversal state
+
+            var shouldDefer = DopplerWritePacer.ShouldDeferWrite(
+                slopeKmPerSec2, catDelayMs, timeSinceLastWriteMs, dopplerReversed);
+
+            if (shouldDefer)
+                return false; // Pacer interfered with low-slope write — violation
+        }
+
+        return true; // All checks passed — pacer never interfered
+    }
+
+    // ─── Concrete Observation Tests (Fact) ───────────────────────────────────────
+
+    /// <summary>
+    /// Observation: with slope = 0.003 km/s² (typical low-elevation pass), the pacer
+    /// never defers writes even at very short intervals with reversal active.
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Fact]
+    public void Low_slope_0_003_never_defers_regardless_of_timing_or_reversal()
+    {
+        const double slope = 0.003; // well below 0.010 threshold
+
+        // Test a range of catDelayMs, timings, and reversal states
+        int[] catDelays = [0, 25, 50, 100, 200];
+        double[] timings = [0, 10, 50, 100, 200, 350, 400, 1000];
+        bool[] reversals = [false, true];
+
+        foreach (var catDelay in catDelays)
+        foreach (var timing in timings)
+        foreach (var reversed in reversals)
+        {
+            var result = DopplerWritePacer.ShouldDeferWrite(slope, catDelay, timing, reversed);
+            Assert.False(result,
+                $"ShouldDeferWrite returned true for low slope={slope}, " +
+                $"catDelay={catDelay}, time={timing}, reversed={reversed}");
+        }
+    }
+
+    /// <summary>
+    /// Observation: with slope = 0.003 km/s², AdaptiveThresholdHz returns the exact
+    /// base threshold for all standard operating thresholds (50 Hz linear, 350 Hz FM).
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Fact]
+    public void Low_slope_0_003_threshold_unchanged_for_standard_values()
+    {
+        const double slope = 0.003;
+
+        Assert.Equal(50, DopplerWritePacer.AdaptiveThresholdHz(50, slope));
+        Assert.Equal(350, DopplerWritePacer.AdaptiveThresholdHz(350, slope));
+        Assert.Equal(1, DopplerWritePacer.AdaptiveThresholdHz(1, slope));
+        Assert.Equal(500, DopplerWritePacer.AdaptiveThresholdHz(500, slope));
+    }
+
+    /// <summary>
+    /// Observation: at the boundary (slope = 0.009999 km/s² — just below threshold),
+    /// both pacer methods still behave as pass-through.
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Fact]
+    public void Boundary_slope_just_below_threshold_preserves_passthrough()
+    {
+        const double slope = 0.009999; // just below 0.010
+
+        // ShouldDeferWrite: never defers
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 50, 0, false));
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 50, 0, true));
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 100, 10, true));
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 0, 350, false));
+
+        // AdaptiveThresholdHz: returns base unchanged
+        Assert.Equal(50, DopplerWritePacer.AdaptiveThresholdHz(50, slope));
+        Assert.Equal(350, DopplerWritePacer.AdaptiveThresholdHz(350, slope));
+    }
+
+    /// <summary>
+    /// Observation: at zero slope (stationary or nearly so), both methods are no-ops.
+    ///
+    /// **Validates: Requirements 3.1, 3.4**
+    /// </summary>
+    [Fact]
+    public void Zero_slope_is_complete_passthrough()
+    {
+        const double slope = 0.0;
+
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 50, 0, false));
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 50, 0, true));
+        Assert.False(DopplerWritePacer.ShouldDeferWrite(slope, 200, 500, true));
+
+        Assert.Equal(50, DopplerWritePacer.AdaptiveThresholdHz(50, slope));
+        Assert.Equal(350, DopplerWritePacer.AdaptiveThresholdHz(350, slope));
+    }
+}

--- a/OscarWatch/Rig/RigController.cs
+++ b/OscarWatch/Rig/RigController.cs
@@ -76,6 +76,7 @@ public sealed class RigController : IRigController, IDisposable
     private bool _blockKnobCapture;
     private DateTime _ignoreDialUntilUtc = DateTime.MinValue;
     private DateTime _lastDialChangeUtc = DateTime.MinValue;
+    private int _previousRangeRateSign;
     private DateTime _suspendDopplerUntilUtc = DateTime.MinValue;
     private DateTime _suspendConnectUntilUtc = DateTime.MinValue;
     private string? _lastConnectError;
@@ -439,6 +440,7 @@ public sealed class RigController : IRigController, IDisposable
         _lastPassDownlinkOnVhf = null;
         _receiveVfo = RigVfo.VfoA;
         _suspendDopplerUntilUtc = DateTime.MinValue;
+        _previousRangeRateSign = 0;
     }
 
     private void RunLoopIteration(bool ignoreDopplerSuspend = false)
@@ -738,6 +740,23 @@ public sealed class RigController : IRigController, IDisposable
         _forceFrequencyApply = false;
         var thresholdHz = _thresholdHz;
         var strategy = context.DopplerStrategy;
+
+        if (!forceApply && settings.DopplerCatLeadEnabled && _propagator is not null && context.TrackState.LookAngles is not null)
+        {
+            var site = _settingsService?.Current.GroundStation ?? new GroundStation();
+            var slope = DopplerCatLead.ComputeRangeRateSlopeKmPerSec2(
+                _propagator, context.TrackState.NoradId, site, DateTime.UtcNow,
+                context.TrackState.LookAngles.RangeRateKmPerSec);
+            var timeSinceLastWrite = (DateTime.UtcNow - _lastWriteUtc).TotalMilliseconds;
+            var dopplerReversed = DetectDopplerReversal(context.TrackState.LookAngles.RangeRateKmPerSec);
+
+            if (DopplerWritePacer.ShouldDeferWrite(slope, settings.ReceiveCatDelayMs(), timeSinceLastWrite, dopplerReversed))
+                return false;
+
+            // Use adaptive threshold on steep legs
+            thresholdHz = DopplerWritePacer.AdaptiveThresholdHz(thresholdHz, slope);
+        }
+
         if (!forceApply && !ShouldWrite(thresholdHz, rxHz, txHz, strategy))
             return false;
 
@@ -822,6 +841,12 @@ public sealed class RigController : IRigController, IDisposable
             _lastWriteUtc = DateTime.UtcNow;
             MarkProgrammaticFrequencySettle();
             FinishOffsetKnobCaptureBlock();
+
+            if (context.TrackState.LookAngles is not null)
+            {
+                var rate = context.TrackState.LookAngles.RangeRateKmPerSec;
+                _previousRangeRateSign = rate > 0 ? 1 : rate < 0 ? -1 : 0;
+            }
         }
 
         if ((writeRx && !wroteRx) || (writeTx && !wroteTx))
@@ -1557,6 +1582,18 @@ public sealed class RigController : IRigController, IDisposable
             site,
             context.TrackState,
             DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Detects whether the Doppler direction has reversed since the last successful write.
+    /// Does not update state — state is updated after a successful write.
+    /// </summary>
+    private bool DetectDopplerReversal(double rangeRateKmPerSec)
+    {
+        var currentSign = rangeRateKmPerSec > 0 ? 1 : rangeRateKmPerSec < 0 ? -1 : 0;
+        if (_previousRangeRateSign == 0 || currentSign == 0)
+            return false; // No previous state or zero-crossing not yet confirmed
+        return currentSign != _previousRangeRateSign;
     }
 
     private static long ToHz(double kHz) => (long)Math.Round(kHz * 1000.0);


### PR DESCRIPTION
Add DopplerWritePacer that adaptively defers CAT writes when Doppler acceleration outpaces the radio's settle time. Near TCA on high passes, the range-rate slope triggers adaptive rate-limiting:

- Defer writes until adaptive interval elapsed (catDelay + settle × blend)
- Widen frequency threshold up to 3× on steep legs
- Enforce full settle window on Doppler direction reversal
- All logic dormant below slope 0.010 km/s² (normal passes unaffected)

Fixes the radio singularity at zenith where commands queue faster than the radio can tune, causing oscillation and overshoot.