### PR TITLE
feat: add Session Planner with weighted interval scheduling

### DIFF
--- a/OscarWatch.Core/Export/SessionPlanExporter.cs
+++ b/OscarWatch.Core/Export/SessionPlanExporter.cs
@@ -1,0 +1,91 @@
+using System.Text;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Core.Export;
+
+/// <summary>
+/// Exports a session plan as CSV or ICS calendar format.
+/// </summary>
+public static class SessionPlanExporter
+{
+    /// <summary>
+    /// Exports the session plan as a CSV string with header and one row per scheduled pass.
+    /// </summary>
+    public static string BuildCsv(SessionPlan plan)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("SatelliteName,NoradId,AOS_UTC,LOS_UTC,MaxElevationDeg,CompositeScore,Status");
+
+        foreach (var scheduled in plan.ScheduledPasses)
+        {
+            var pass = scheduled.Scored.Pass;
+            sb.AppendLine(
+                $"{pass.SatelliteName},{pass.NoradId}," +
+                $"{FormatUtcCsv(pass.AosUtc)},{FormatUtcCsv(pass.LosUtc)}," +
+                $"{pass.MaxElevationDeg:F1},{scheduled.Scored.CompositeScore:F1}," +
+                $"{scheduled.Reason}");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Exports the session plan as an ICS calendar string with VALARM pre-alerts.
+    /// </summary>
+    public static string BuildCalendar(
+        SessionPlan plan,
+        GroundStation station,
+        int preAlertMinutes = 3)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("BEGIN:VCALENDAR");
+        sb.AppendLine("VERSION:2.0");
+        sb.AppendLine("PRODID:-//OscarWatch//Session Planner//EN");
+        sb.AppendLine("CALSCALE:GREGORIAN");
+        sb.AppendLine($"X-WR-CALNAME:{Escape($"OscarWatch Session Plan")}");
+
+        foreach (var scheduled in plan.ScheduledPasses)
+        {
+            var pass = scheduled.Scored.Pass;
+
+            sb.AppendLine("BEGIN:VEVENT");
+            sb.AppendLine($"UID:{pass.NoradId}-{pass.AosUtc.Ticks}@oscarwatch.org");
+            sb.AppendLine($"DTSTAMP:{FormatUtc(DateTime.UtcNow)}");
+            sb.AppendLine($"DTSTART:{FormatUtc(pass.AosUtc)}");
+            sb.AppendLine($"DTEND:{FormatUtc(pass.LosUtc)}");
+            sb.AppendLine($"SUMMARY:{Escape($"{pass.SatelliteName} pass (max {pass.MaxElevationDeg:F1}°)")}");
+            sb.AppendLine(
+                "DESCRIPTION:" + Escape(
+                    $"Max elevation {pass.MaxElevationDeg:F1}°\n" +
+                    $"Composite score {scheduled.Scored.CompositeScore:F1}\n" +
+                    $"Duration {pass.Duration:mm\\:ss}\n" +
+                    $"Status: {scheduled.Reason}"));
+            sb.AppendLine($"LOCATION:{Escape($"{station.DisplayName} ({station.GridSquare})")}");
+
+            sb.AppendLine("BEGIN:VALARM");
+            sb.AppendLine($"TRIGGER:-PT{preAlertMinutes}M");
+            sb.AppendLine("ACTION:DISPLAY");
+            sb.AppendLine($"DESCRIPTION:{Escape($"{pass.SatelliteName} AOS in {preAlertMinutes} minutes")}");
+            sb.AppendLine("END:VALARM");
+
+            sb.AppendLine("END:VEVENT");
+        }
+
+        sb.AppendLine("END:VCALENDAR");
+        return sb.ToString();
+    }
+
+    private static string FormatUtc(DateTime utc) =>
+        utc.ToUniversalTime().ToString("yyyyMMdd'T'HHmmss'Z'");
+
+    private static string FormatUtcCsv(DateTime utc) =>
+        utc.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace(";", "\\;", StringComparison.Ordinal)
+            .Replace(",", "\\,", StringComparison.Ordinal)
+            .Replace("\r\n", "\\n", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
+}

--- a/OscarWatch.Core/Models/AppSettings.cs
+++ b/OscarWatch.Core/Models/AppSettings.cs
@@ -72,4 +72,8 @@ public sealed class AppSettings
     public QsoLogbookSettings QsoLogbook { get; set; } = new();
     /// <summary>Transponder conflicts the user confirmed keeping locally instead of the published version.</summary>
     public List<TransponderConflictAcknowledgment> TransponderConflictAcknowledgments { get; set; } = [];
+    /// <summary>Operator-assigned satellite priority (1=highest, 10=lowest). Key: satellite name.</summary>
+    public Dictionary<string, int> SatellitePriorities { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>Pre-alert lead time in minutes for session planner (1–15, default 3).</summary>
+    public int SessionPlannerPreAlertMinutes { get; set; } = 3;
 }

--- a/OscarWatch.Core/Properties/AssemblyInfo.cs
+++ b/OscarWatch.Core/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("OscarWatch")]
 [assembly: InternalsVisibleTo("OscarWatch.Tests")]

--- a/OscarWatch.Core/Services/SettingsService.cs
+++ b/OscarWatch.Core/Services/SettingsService.cs
@@ -255,6 +255,7 @@ public sealed class SettingsService : ISettingsService, IDisposable
         settings.TleSource ??= new TleSourceSettings();
         settings.TleSource = TleSourceResolver.NormalizeLegacyCustomUrl(settings.TleSource);
         settings.TransponderConflictAcknowledgments ??= [];
+        settings.SatellitePriorities ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/OscarWatch.Core/SessionPlanner/PassQualityScorer.cs
+++ b/OscarWatch.Core/SessionPlanner/PassQualityScorer.cs
@@ -1,0 +1,112 @@
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Pure static scoring functions for pass quality assessment.
+/// No dependencies — directly testable.
+/// </summary>
+public static class PassQualityScorer
+{
+    /// <summary>
+    /// Computes the quality score in [0.0, 1.0] for a candidate pass.
+    /// Formula: clamp(elev/90)*0.5 + clamp(dur/15)*0.3 + transponderFactor*0.2
+    /// </summary>
+    public static double ComputeScore(
+        double maxElevationDeg,
+        double durationMinutes,
+        TransponderCategory transponderCategory)
+    {
+        var elevationComponent = ClampToUnit(maxElevationDeg / 90.0);
+        var durationComponent = ClampToUnit(durationMinutes / 15.0);
+        var transponderFactor = GetTransponderFactor(transponderCategory);
+
+        return elevationComponent * 0.5 + durationComponent * 0.3 + transponderFactor * 0.2;
+    }
+
+    /// <summary>
+    /// Computes the composite score for a candidate pass.
+    /// Formula: qualityScore × (11 − satellitePriority).
+    /// Result is in [0.0, 10.0] when qualityScore ∈ [0,1] and priority ∈ [1,10].
+    /// </summary>
+    public static double ComputeCompositeScore(double qualityScore, int satellitePriority)
+    {
+        return qualityScore * (11 - satellitePriority);
+    }
+
+    /// <summary>
+    /// Clamps a value to [0.0, 1.0], treating NaN and negative infinity as 0.0
+    /// and positive infinity as 1.0.
+    /// </summary>
+    private static double ClampToUnit(double value)
+    {
+        if (double.IsNaN(value) || value <= 0.0) return 0.0;
+        if (value >= 1.0) return 1.0;
+        return value;
+    }
+
+    /// <summary>
+    /// Determines transponder category from satellite radio entry modes.
+    /// Examines uplink/downlink mode strings to classify as Linear, Fm, Mixed, or Unknown.
+    /// </summary>
+    public static TransponderCategory ClassifyTransponder(SatelliteRadioEntry? radioEntry)
+    {
+        if (radioEntry is null || radioEntry.Modes.Count == 0)
+            return TransponderCategory.Unknown;
+
+        var hasLinear = false;
+        var hasFm = false;
+
+        foreach (var mode in radioEntry.Modes)
+        {
+            // Skip beacon-only entries — they don't represent usable transponders
+            if (mode.IsBeaconOnly)
+                continue;
+
+            if (mode.IsFmMode)
+            {
+                hasFm = true;
+            }
+            else if (IsLinearMode(mode))
+            {
+                hasLinear = true;
+            }
+        }
+
+        return (hasLinear, hasFm) switch
+        {
+            (true, true) => TransponderCategory.Mixed,
+            (true, false) => TransponderCategory.Linear,
+            (false, true) => TransponderCategory.Fm,
+            _ => TransponderCategory.Unknown
+        };
+    }
+
+    /// <summary>
+    /// Returns the scoring factor for a given transponder category.
+    /// </summary>
+    private static double GetTransponderFactor(TransponderCategory category) => category switch
+    {
+        TransponderCategory.Linear => 1.0,
+        TransponderCategory.Fm => 0.6,
+        TransponderCategory.Mixed => 0.8,
+        TransponderCategory.Unknown => 0.7,
+        _ => 0.7
+    };
+
+    /// <summary>
+    /// Checks if a transponder mode is linear (SSB, CW, or similar non-FM modes).
+    /// </summary>
+    private static bool IsLinearMode(SatelliteTransponderMode mode)
+    {
+        return ContainsLinearIndicator(mode.UplinkMode)
+            || ContainsLinearIndicator(mode.DownlinkMode);
+    }
+
+    private static bool ContainsLinearIndicator(string modeString)
+    {
+        return modeString.Contains("SSB", StringComparison.OrdinalIgnoreCase)
+            || modeString.Contains("CW", StringComparison.OrdinalIgnoreCase)
+            || modeString.Contains("Linear", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OscarWatch.Core/SessionPlanner/PlanExecutionState.cs
+++ b/OscarWatch.Core/SessionPlanner/PlanExecutionState.cs
@@ -1,0 +1,19 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Represents the execution state of the session plan executor.
+/// </summary>
+public enum PlanExecutionState
+{
+    /// <summary>No plan is active.</summary>
+    Idle,
+
+    /// <summary>Plan is actively executing with automatic focus switching.</summary>
+    Running,
+
+    /// <summary>Plan execution is paused (manual override active).</summary>
+    Paused,
+
+    /// <summary>All scheduled passes have completed.</summary>
+    Completed
+}

--- a/OscarWatch.Core/SessionPlanner/PlanExecutor.cs
+++ b/OscarWatch.Core/SessionPlanner/PlanExecutor.cs
@@ -1,0 +1,286 @@
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Event args for an AOS pre-alert notification.
+/// </summary>
+public sealed class AosPreAlertEventArgs : EventArgs
+{
+    public required string SatelliteName { get; init; }
+    public TimeSpan TimeUntilAos { get; init; }
+    public double MaxElevationDeg { get; init; }
+}
+
+/// <summary>
+/// Event args for a focus switch event.
+/// </summary>
+public sealed class FocusSwitchEventArgs : EventArgs
+{
+    public required string NoradId { get; init; }
+    public required string SatelliteName { get; init; }
+}
+
+/// <summary>
+/// Timer-driven state machine that executes a session plan by switching focused satellite
+/// at each pass's AOS time and raising pre-alert notifications. The caller (ViewModel)
+/// drives the timer and calls <see cref="Tick"/> — this class does not own a timer.
+/// </summary>
+public sealed class PlanExecutor : IDisposable
+{
+    private readonly ILiveTrackingService _liveTracking;
+    private int _preAlertMinutes;
+    private string? _lastSwitchedNoradId;
+    private readonly HashSet<string> _alertedPassIds = new();
+
+    public PlanExecutor(ILiveTrackingService liveTracking)
+    {
+        _liveTracking = liveTracking ?? throw new ArgumentNullException(nameof(liveTracking));
+    }
+
+    /// <summary>The currently active session plan, or null if idle.</summary>
+    public SessionPlan? ActivePlan { get; private set; }
+
+    /// <summary>Current execution state.</summary>
+    public PlanExecutionState State { get; private set; } = PlanExecutionState.Idle;
+
+    /// <summary>The pass currently in progress (AOS ≤ now ≤ LOS), or null if in a gap.</summary>
+    public ScheduledPass? CurrentPass { get; private set; }
+
+    /// <summary>The next upcoming pass, or null if there are no more passes.</summary>
+    public ScheduledPass? NextPass { get; private set; }
+
+    /// <summary>Time remaining until the next focus switch (next AOS), or null if no upcoming pass.</summary>
+    public TimeSpan? TimeToNextSwitch { get; private set; }
+
+    /// <summary>True when manual override is active (plan is paused due to external focus change).</summary>
+    public bool IsManualOverrideActive { get; private set; }
+
+    /// <summary>Raised when a pre-alert notification should be shown to the operator.</summary>
+    public event EventHandler<AosPreAlertEventArgs>? PreAlertRaised;
+
+    /// <summary>Raised when the focused satellite is switched.</summary>
+    public event EventHandler<FocusSwitchEventArgs>? FocusSwitched;
+
+    /// <summary>Raised when all passes in the plan have completed.</summary>
+    public event EventHandler? PlanCompleted;
+
+    /// <summary>
+    /// Start executing a session plan.
+    /// </summary>
+    /// <param name="plan">The plan to execute.</param>
+    /// <param name="preAlertMinutes">Minutes before AOS to raise pre-alert (1–15, default 3).</param>
+    public void Start(SessionPlan plan, int preAlertMinutes = 3)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        ActivePlan = plan;
+        _preAlertMinutes = Math.Clamp(preAlertMinutes, 1, 15);
+        _lastSwitchedNoradId = null;
+        _alertedPassIds.Clear();
+        IsManualOverrideActive = false;
+        CurrentPass = null;
+        NextPass = null;
+        TimeToNextSwitch = null;
+        State = PlanExecutionState.Running;
+    }
+
+    /// <summary>
+    /// Stop execution and clear the active plan.
+    /// </summary>
+    public void Stop()
+    {
+        State = PlanExecutionState.Idle;
+        ActivePlan = null;
+        CurrentPass = null;
+        NextPass = null;
+        TimeToNextSwitch = null;
+        IsManualOverrideActive = false;
+        _lastSwitchedNoradId = null;
+        _alertedPassIds.Clear();
+    }
+
+    /// <summary>
+    /// Pause execution (manual override). Automatic switching is suspended.
+    /// </summary>
+    public void Pause()
+    {
+        if (State == PlanExecutionState.Running)
+        {
+            State = PlanExecutionState.Paused;
+            IsManualOverrideActive = true;
+        }
+    }
+
+    /// <summary>
+    /// Resume automatic switching after a pause/manual override.
+    /// </summary>
+    public void Resume()
+    {
+        if (State == PlanExecutionState.Paused)
+        {
+            State = PlanExecutionState.Running;
+            IsManualOverrideActive = false;
+        }
+    }
+
+    /// <summary>
+    /// Called by the timer tick (typically 1s interval). Evaluates the current time against
+    /// the plan and returns the appropriate action. Pure state transition logic.
+    /// </summary>
+    /// <param name="utcNow">Current UTC time.</param>
+    /// <returns>The action to perform at this tick.</returns>
+    internal PlanExecutorAction Tick(DateTime utcNow)
+    {
+        if (ActivePlan is null || State == PlanExecutionState.Idle || State == PlanExecutionState.Completed)
+            return new PlanExecutorAction.NoAction();
+
+        var passes = ActivePlan.ScheduledPasses;
+        if (passes.Count == 0)
+        {
+            State = PlanExecutionState.Completed;
+            PlanCompleted?.Invoke(this, EventArgs.Empty);
+            return new PlanExecutorAction.MarkCompleted();
+        }
+
+        // Find current pass: pass whose [AOS, LOS] contains utcNow
+        var currentPass = FindCurrentPass(passes, utcNow);
+        CurrentPass = currentPass;
+
+        // Find next pass (first pass whose AOS > utcNow)
+        var nextPass = FindNextPass(passes, utcNow);
+        NextPass = nextPass;
+
+        // Compute time to next switch
+        TimeToNextSwitch = nextPass is not null
+            ? nextPass.Scored.Pass.AosUtc - utcNow
+            : null;
+
+        // Check if final pass LOS has been exceeded → plan completed
+        var finalPass = passes[^1];
+        if (utcNow > finalPass.Scored.Pass.LosUtc)
+        {
+            State = PlanExecutionState.Completed;
+            CurrentPass = null;
+            NextPass = null;
+            TimeToNextSwitch = null;
+            PlanCompleted?.Invoke(this, EventArgs.Empty);
+            return new PlanExecutorAction.MarkCompleted();
+        }
+
+        // If paused, don't perform automatic actions (but still update state above)
+        if (State == PlanExecutionState.Paused)
+            return new PlanExecutorAction.NoAction();
+
+        // Pre-alert logic: fire at max(previousLOS, AOS - preAlertMinutes)
+        var preAlertAction = CheckPreAlert(passes, utcNow);
+        if (preAlertAction is not null)
+            return preAlertAction;
+
+        // Focus switch logic: if utcNow reaches a pass's AOS and we haven't switched yet
+        if (currentPass is not null)
+        {
+            var noradId = currentPass.Scored.Pass.NoradId;
+            if (_lastSwitchedNoradId != noradId)
+            {
+                _lastSwitchedNoradId = noradId;
+
+                try
+                {
+                    _liveTracking.FocusedNoradId = noradId;
+                }
+                catch
+                {
+                    // Log error but continue to next pass (per error handling spec)
+                }
+
+                FocusSwitched?.Invoke(this, new FocusSwitchEventArgs
+                {
+                    NoradId = noradId,
+                    SatelliteName = currentPass.Scored.Pass.SatelliteName
+                });
+
+                return new PlanExecutorAction.SwitchFocus(noradId);
+            }
+        }
+
+        // During gaps, retain FocusedNoradId of most recently completed pass → NoAction
+        return new PlanExecutorAction.NoAction();
+    }
+
+    private static ScheduledPass? FindCurrentPass(IReadOnlyList<ScheduledPass> passes, DateTime utcNow)
+    {
+        for (var i = 0; i < passes.Count; i++)
+        {
+            var pass = passes[i];
+            if (utcNow >= pass.Scored.Pass.AosUtc && utcNow <= pass.Scored.Pass.LosUtc)
+                return pass;
+        }
+        return null;
+    }
+
+    private static ScheduledPass? FindNextPass(IReadOnlyList<ScheduledPass> passes, DateTime utcNow)
+    {
+        for (var i = 0; i < passes.Count; i++)
+        {
+            if (passes[i].Scored.Pass.AosUtc > utcNow)
+                return passes[i];
+        }
+        return null;
+    }
+
+    private PlanExecutorAction? CheckPreAlert(IReadOnlyList<ScheduledPass> passes, DateTime utcNow)
+    {
+        for (var i = 0; i < passes.Count; i++)
+        {
+            var pass = passes[i];
+            var passId = pass.Scored.Id;
+
+            // Skip already-alerted passes
+            if (_alertedPassIds.Contains(passId))
+                continue;
+
+            var aos = pass.Scored.Pass.AosUtc;
+
+            // Only consider passes whose AOS is in the future
+            if (aos <= utcNow)
+                continue;
+
+            // Compute alert time: max(previousLOS, AOS - preAlertMinutes)
+            var alertTime = aos - TimeSpan.FromMinutes(_preAlertMinutes);
+
+            if (i > 0)
+            {
+                var previousLos = passes[i - 1].Scored.Pass.LosUtc;
+                if (previousLos > alertTime)
+                    alertTime = previousLos;
+            }
+
+            // Fire if we've reached or passed the alert time
+            if (utcNow >= alertTime)
+            {
+                _alertedPassIds.Add(passId);
+
+                var timeUntilAos = aos - utcNow;
+                var maxElev = pass.Scored.Pass.MaxElevationDeg;
+                var satName = pass.Scored.Pass.SatelliteName;
+
+                PreAlertRaised?.Invoke(this, new AosPreAlertEventArgs
+                {
+                    SatelliteName = satName,
+                    TimeUntilAos = timeUntilAos,
+                    MaxElevationDeg = maxElev
+                });
+
+                return new PlanExecutorAction.RaisePreAlert(satName, timeUntilAos, maxElev);
+            }
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+}

--- a/OscarWatch.Core/SessionPlanner/PlanExecutorAction.cs
+++ b/OscarWatch.Core/SessionPlanner/PlanExecutorAction.cs
@@ -1,0 +1,21 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Represents the action determined by a single PlanExecutor tick.
+/// </summary>
+public abstract record PlanExecutorAction
+{
+    private PlanExecutorAction() { }
+
+    /// <summary>No action required at this tick.</summary>
+    public sealed record NoAction : PlanExecutorAction;
+
+    /// <summary>Switch the focused satellite to the specified NORAD ID.</summary>
+    public sealed record SwitchFocus(string NoradId) : PlanExecutorAction;
+
+    /// <summary>Raise a pre-alert notification for an upcoming pass.</summary>
+    public sealed record RaisePreAlert(string SatelliteName, TimeSpan TimeUntilAos, double MaxElevationDeg) : PlanExecutorAction;
+
+    /// <summary>The final pass has completed; mark the plan as done.</summary>
+    public sealed record MarkCompleted : PlanExecutorAction;
+}

--- a/OscarWatch.Core/SessionPlanner/ScheduledPass.cs
+++ b/OscarWatch.Core/SessionPlanner/ScheduledPass.cs
@@ -1,0 +1,24 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// A pass selected for inclusion in a session plan.
+/// </summary>
+public sealed class ScheduledPass
+{
+    public required ScoredPass Scored { get; init; }
+
+    /// <summary>Why this pass was included in the plan.</summary>
+    public PassSelectionReason Reason { get; init; }
+}
+
+/// <summary>
+/// Indicates how a pass was selected for the session plan.
+/// </summary>
+public enum PassSelectionReason
+{
+    /// <summary>Selected by the weighted interval scheduling algorithm.</summary>
+    AlgorithmSelected,
+
+    /// <summary>Manually force-included by the operator.</summary>
+    ForceIncluded
+}

--- a/OscarWatch.Core/SessionPlanner/ScoredPass.cs
+++ b/OscarWatch.Core/SessionPlanner/ScoredPass.cs
@@ -1,0 +1,23 @@
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// A candidate pass with its computed quality and composite scores.
+/// </summary>
+public sealed class ScoredPass
+{
+    public required PassInfo Pass { get; init; }
+
+    /// <summary>Quality score in [0.0, 1.0] based on elevation, duration, and transponder type.</summary>
+    public double QualityScore { get; init; }
+
+    /// <summary>Operator-assigned satellite priority (1 = highest, 10 = lowest).</summary>
+    public int SatellitePriority { get; init; }
+
+    /// <summary>Composite score: QualityScore × (11 − SatellitePriority). Range [0.0, 10.0].</summary>
+    public double CompositeScore { get; init; }
+
+    /// <summary>Unique identifier for force-include/exclude operations.</summary>
+    public string Id => $"{Pass.NoradId}:{Pass.AosUtc.Ticks}";
+}

--- a/OscarWatch.Core/SessionPlanner/SessionPlan.cs
+++ b/OscarWatch.Core/SessionPlanner/SessionPlan.cs
@@ -1,0 +1,26 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// The complete session plan — immutable once generated.
+/// </summary>
+public sealed class SessionPlan
+{
+    public DateTime SessionStartUtc { get; init; }
+    public DateTime SessionEndUtc { get; init; }
+
+    public IReadOnlyList<ScheduledPass> ScheduledPasses { get; init; } = [];
+    public IReadOnlyList<ScoredPass> AllCandidates { get; init; } = [];
+    public IReadOnlySet<string> ExcludedIds { get; init; } = new HashSet<string>();
+    public IReadOnlySet<string> ForcedInclusionIds { get; init; } = new HashSet<string>();
+
+    /// <summary>Sum of durations of all scheduled passes.</summary>
+    public TimeSpan TotalOperatingTime =>
+        ScheduledPasses.Aggregate(TimeSpan.Zero, (sum, sp) => sum + sp.Scored.Pass.Duration);
+
+    /// <summary>Session duration minus total operating time.</summary>
+    public TimeSpan TotalGapTime =>
+        (SessionEndUtc - SessionStartUtc) - TotalOperatingTime;
+
+    /// <summary>Number of passes in the schedule.</summary>
+    public int ScheduledCount => ScheduledPasses.Count;
+}

--- a/OscarWatch.Core/SessionPlanner/SessionPlanPersistence.cs
+++ b/OscarWatch.Core/SessionPlanner/SessionPlanPersistence.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OscarWatch.Core.Models;
+
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// JSON serialisation and deserialisation for session plans.
+/// </summary>
+public static class SessionPlanPersistence
+{
+    private const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions SerialiserOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    /// <summary>
+    /// Serialises a session plan to a JSON string.
+    /// </summary>
+    public static string Serialise(SessionPlan plan)
+    {
+        var dto = new SessionPlanDto
+        {
+            Version = CurrentVersion,
+            SessionStartUtc = plan.SessionStartUtc,
+            SessionEndUtc = plan.SessionEndUtc,
+            GeneratedUtc = DateTime.UtcNow,
+            Parameters = new PlanParametersDto(),
+            ScheduledPasses = plan.ScheduledPasses.Select(sp => new ScheduledPassDto
+            {
+                SatelliteName = sp.Scored.Pass.SatelliteName,
+                NoradId = sp.Scored.Pass.NoradId,
+                AosUtc = sp.Scored.Pass.AosUtc,
+                LosUtc = sp.Scored.Pass.LosUtc,
+                MaxElevationDeg = sp.Scored.Pass.MaxElevationDeg,
+                MaxElevationUtc = sp.Scored.Pass.MaxElevationUtc,
+                QualityScore = sp.Scored.QualityScore,
+                CompositeScore = sp.Scored.CompositeScore,
+                SatellitePriority = sp.Scored.SatellitePriority,
+                Reason = sp.Reason
+            }).ToList(),
+            ExcludedIds = plan.ExcludedIds.ToList(),
+            ForcedInclusionIds = plan.ForcedInclusionIds.ToList()
+        };
+
+        return JsonSerializer.Serialize(dto, SerialiserOptions);
+    }
+
+    /// <summary>
+    /// Deserialises a JSON string to a session plan.
+    /// Returns null for malformed JSON or version mismatch.
+    /// </summary>
+    public static SessionPlan? Deserialise(string json)
+    {
+        try
+        {
+            var dto = JsonSerializer.Deserialize<SessionPlanDto>(json, SerialiserOptions);
+
+            if (dto is null || dto.Version != CurrentVersion)
+                return null;
+
+            var scheduledPasses = dto.ScheduledPasses.Select(sp =>
+            {
+                var passInfo = new PassInfo
+                {
+                    SatelliteName = sp.SatelliteName,
+                    NoradId = sp.NoradId,
+                    AosUtc = sp.AosUtc,
+                    LosUtc = sp.LosUtc,
+                    MaxElevationDeg = sp.MaxElevationDeg,
+                    MaxElevationUtc = sp.MaxElevationUtc
+                };
+
+                var scored = new ScoredPass
+                {
+                    Pass = passInfo,
+                    QualityScore = sp.QualityScore,
+                    CompositeScore = sp.CompositeScore,
+                    SatellitePriority = sp.SatellitePriority
+                };
+
+                return new ScheduledPass
+                {
+                    Scored = scored,
+                    Reason = sp.Reason
+                };
+            }).ToList();
+
+            // On deserialise, AllCandidates is reconstructed from the scheduled passes.
+            // The original full candidate list isn't preserved across save/load — only
+            // scheduled passes are stored. This means a loaded plan cannot be meaningfully
+            // "re-solved" without re-running prediction, but all scheduled data is intact.
+            var allCandidates = scheduledPasses
+                .Select(sp => sp.Scored)
+                .ToList();
+
+            return new SessionPlan
+            {
+                SessionStartUtc = dto.SessionStartUtc,
+                SessionEndUtc = dto.SessionEndUtc,
+                ScheduledPasses = scheduledPasses,
+                AllCandidates = allCandidates,
+                ExcludedIds = dto.ExcludedIds.ToHashSet(),
+                ForcedInclusionIds = dto.ForcedInclusionIds.ToHashSet()
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    #region Internal DTOs
+
+    internal sealed class SessionPlanDto
+    {
+        public int Version { get; set; }
+        public DateTime SessionStartUtc { get; set; }
+        public DateTime SessionEndUtc { get; set; }
+        public DateTime GeneratedUtc { get; set; }
+        public PlanParametersDto Parameters { get; set; } = new();
+        public List<ScheduledPassDto> ScheduledPasses { get; set; } = [];
+        public List<string> ExcludedIds { get; set; } = [];
+        public List<string> ForcedInclusionIds { get; set; } = [];
+    }
+
+    internal sealed class PlanParametersDto
+    {
+        public double MinimumElevationDeg { get; set; } = 5.0;
+        public int PreAlertMinutes { get; set; } = 3;
+        public Dictionary<string, int> Priorities { get; set; } = new();
+    }
+
+    internal sealed class ScheduledPassDto
+    {
+        public string SatelliteName { get; set; } = string.Empty;
+        public string NoradId { get; set; } = string.Empty;
+        public DateTime AosUtc { get; set; }
+        public DateTime LosUtc { get; set; }
+        public double MaxElevationDeg { get; set; }
+        public DateTime MaxElevationUtc { get; set; }
+        public double QualityScore { get; set; }
+        public double CompositeScore { get; set; }
+        public int SatellitePriority { get; set; }
+        public PassSelectionReason Reason { get; set; }
+    }
+
+    #endregion
+}

--- a/OscarWatch.Core/SessionPlanner/SessionPlannerService.cs
+++ b/OscarWatch.Core/SessionPlanner/SessionPlannerService.cs
@@ -1,0 +1,186 @@
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Orchestrates session plan generation: predicts passes, scores them,
+/// and selects the optimal non-overlapping subset via weighted interval scheduling.
+/// </summary>
+public sealed class SessionPlannerService
+{
+    private static readonly TimeSpan MaxSessionDuration = TimeSpan.FromHours(48);
+
+    private readonly TrackingOrchestrator _orchestrator;
+    private readonly ISatelliteDatabaseService _satelliteDb;
+    private readonly ISettingsService _settings;
+
+    public SessionPlannerService(
+        TrackingOrchestrator orchestrator,
+        ISatelliteDatabaseService satelliteDb,
+        ISettingsService settings)
+    {
+        _orchestrator = orchestrator;
+        _satelliteDb = satelliteDb;
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Generates a session plan for the given time window.
+    /// Validates the window, predicts passes, scores each candidate,
+    /// and selects the optimal non-overlapping subset.
+    /// </summary>
+    public async Task<SessionPlan> GeneratePlanAsync(
+        DateTime sessionStartUtc,
+        DateTime sessionEndUtc,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateSessionWindow(sessionStartUtc, sessionEndUtc);
+
+        var settings = _settings.Current;
+        var site = settings.GroundStation;
+        var minElevation = settings.MinimumElevationDeg;
+        // Prediction must cover from now to the end of the session window,
+        // since GetPassesAsync starts at UtcNow regardless of session start.
+        var hoursFromNowToEnd = (int)Math.Ceiling((sessionEndUtc - DateTime.UtcNow).TotalHours);
+        var predictionHours = Math.Max(1, hoursFromNowToEnd);
+        var minDurationMinutes = settings.PassFilterMinDurationMinutes;
+
+        var allPasses = await _orchestrator.GetPassesAsync(
+            site,
+            minElevation,
+            predictionHours,
+            minDurationMinutes,
+            cancellationToken);
+
+        // Filter passes to only those within the session window.
+        var windowPasses = allPasses
+            .Where(p => p.AosUtc >= sessionStartUtc && p.LosUtc <= sessionEndUtc)
+            .ToList();
+
+        var priorities = settings.SatellitePriorities;
+        var candidates = ScorePasses(windowPasses, priorities);
+
+        var scheduled = WeightedIntervalScheduler.Solve(
+            candidates,
+            forcedInclusionIds: null,
+            minimumElevationDeg: minElevation);
+
+        return new SessionPlan
+        {
+            SessionStartUtc = sessionStartUtc,
+            SessionEndUtc = sessionEndUtc,
+            ScheduledPasses = scheduled,
+            AllCandidates = candidates,
+            ExcludedIds = new HashSet<string>(),
+            ForcedInclusionIds = new HashSet<string>()
+        };
+    }
+
+    /// <summary>
+    /// Regenerates the plan after excluding or force-including passes.
+    /// Takes the existing candidates, filters out excluded, and re-solves.
+    /// </summary>
+    public SessionPlan AdjustPlan(
+        SessionPlan currentPlan,
+        IReadOnlySet<string>? excludedIds = null,
+        IReadOnlySet<string>? forcedInclusionIds = null)
+    {
+        var effectiveExcluded = excludedIds ?? new HashSet<string>();
+        var effectiveForced = forcedInclusionIds ?? new HashSet<string>();
+
+        // Remove excluded candidates from the candidate pool.
+        var filteredCandidates = currentPlan.AllCandidates
+            .Where(c => !effectiveExcluded.Contains(c.Id))
+            .ToList();
+
+        var minElevation = _settings.Current.MinimumElevationDeg;
+
+        var scheduled = WeightedIntervalScheduler.Solve(
+            filteredCandidates,
+            forcedInclusionIds: effectiveForced,
+            minimumElevationDeg: minElevation);
+
+        return new SessionPlan
+        {
+            SessionStartUtc = currentPlan.SessionStartUtc,
+            SessionEndUtc = currentPlan.SessionEndUtc,
+            ScheduledPasses = scheduled,
+            AllCandidates = currentPlan.AllCandidates,
+            ExcludedIds = effectiveExcluded.ToHashSet(),
+            ForcedInclusionIds = effectiveForced.ToHashSet()
+        };
+    }
+
+    /// <summary>
+    /// Rounds a DateTime up to the next 15-minute boundary.
+    /// If already on a 15-minute boundary with zero seconds, returns unchanged.
+    /// </summary>
+    public static DateTime RoundUpTo15Minutes(DateTime input)
+    {
+        var totalMinutes = input.Hour * 60 + input.Minute;
+        var seconds = input.Second;
+        var ticks = input.Ticks % TimeSpan.TicksPerSecond;
+
+        // If already exactly on a 15-minute boundary, return as-is.
+        if (totalMinutes % 15 == 0 && seconds == 0 && ticks == 0)
+            return input;
+
+        var nextBoundaryMinutes = ((totalMinutes / 15) + 1) * 15;
+        var minutesToAdd = nextBoundaryMinutes - totalMinutes;
+
+        // Strip seconds and sub-second components, then add the minutes.
+        var truncated = new DateTime(
+            input.Year, input.Month, input.Day,
+            input.Hour, input.Minute, 0, input.Kind);
+
+        return truncated.AddMinutes(minutesToAdd);
+    }
+
+    /// <summary>
+    /// Validates the session window. Throws ArgumentException for invalid windows.
+    /// </summary>
+    private static void ValidateSessionWindow(DateTime sessionStartUtc, DateTime sessionEndUtc)
+    {
+        if (sessionEndUtc <= sessionStartUtc)
+            throw new ArgumentException(
+                "Session end time must be after the start time.");
+
+        if (sessionEndUtc - sessionStartUtc > MaxSessionDuration)
+            throw new ArgumentException(
+                "Session duration must not exceed 48 hours.");
+    }
+
+    /// <summary>
+    /// Scores each candidate pass using elevation, duration, transponder type, and satellite priority.
+    /// </summary>
+    private List<ScoredPass> ScorePasses(
+        IReadOnlyList<PassInfo> passes,
+        Dictionary<string, int> priorities)
+    {
+        var scored = new List<ScoredPass>(passes.Count);
+
+        foreach (var pass in passes)
+        {
+            var radioEntry = _satelliteDb.TryGetEntry(pass.SatelliteName, pass.NoradId);
+            var transponderCategory = PassQualityScorer.ClassifyTransponder(radioEntry);
+            var qualityScore = PassQualityScorer.ComputeScore(
+                pass.MaxElevationDeg,
+                pass.Duration.TotalMinutes,
+                transponderCategory);
+
+            var priority = priorities.TryGetValue(pass.SatelliteName, out var p) ? p : 5;
+            var compositeScore = PassQualityScorer.ComputeCompositeScore(qualityScore, priority);
+
+            scored.Add(new ScoredPass
+            {
+                Pass = pass,
+                QualityScore = qualityScore,
+                SatellitePriority = priority,
+                CompositeScore = compositeScore
+            });
+        }
+
+        return scored;
+    }
+}

--- a/OscarWatch.Core/SessionPlanner/TransponderCategory.cs
+++ b/OscarWatch.Core/SessionPlanner/TransponderCategory.cs
@@ -1,0 +1,19 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Categorises a satellite's transponder type for quality scoring.
+/// </summary>
+public enum TransponderCategory
+{
+    /// <summary>Linear transponder — factor 1.0.</summary>
+    Linear,
+
+    /// <summary>FM transponder — factor 0.6.</summary>
+    Fm,
+
+    /// <summary>Both linear and FM modes available — factor 0.8.</summary>
+    Mixed,
+
+    /// <summary>No transponder data in catalogue — factor 0.7.</summary>
+    Unknown
+}

--- a/OscarWatch.Core/SessionPlanner/WeightedIntervalScheduler.cs
+++ b/OscarWatch.Core/SessionPlanner/WeightedIntervalScheduler.cs
@@ -1,0 +1,234 @@
+namespace OscarWatch.Core.SessionPlanner;
+
+/// <summary>
+/// Selects the maximum-weight non-overlapping subset of candidate passes
+/// using dynamic-programming weighted interval scheduling.
+/// O(n log n) time, O(n) space.
+/// </summary>
+public static class WeightedIntervalScheduler
+{
+    /// <summary>
+    /// Selects the optimal non-overlapping subset of candidate passes,
+    /// respecting forced inclusions and minimum elevation filtering.
+    /// </summary>
+    /// <param name="candidates">Scored candidate passes (any order).</param>
+    /// <param name="forcedInclusionIds">Pass IDs that must appear in the solution (may be null).</param>
+    /// <param name="minimumElevationDeg">Passes below this max elevation are excluded.</param>
+    /// <returns>Optimal non-overlapping selection ordered by AOS time.</returns>
+    public static IReadOnlyList<ScheduledPass> Solve(
+        IReadOnlyList<ScoredPass> candidates,
+        IReadOnlySet<string>? forcedInclusionIds = null,
+        double minimumElevationDeg = 0)
+    {
+        if (candidates.Count == 0)
+            return [];
+
+        // Step 1: Filter by minimum elevation threshold.
+        var filtered = new List<ScoredPass>();
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            if (candidates[i].Pass.MaxElevationDeg >= minimumElevationDeg)
+                filtered.Add(candidates[i]);
+        }
+
+        if (filtered.Count == 0)
+            return [];
+
+        // Separate forced passes from algorithm candidates.
+        var forcedIds = forcedInclusionIds ?? new HashSet<string>();
+        var forcedPasses = new List<ScoredPass>();
+        var remainingCandidates = new List<ScoredPass>();
+
+        for (int i = 0; i < filtered.Count; i++)
+        {
+            if (forcedIds.Contains(filtered[i].Id))
+                forcedPasses.Add(filtered[i]);
+            else
+                remainingCandidates.Add(filtered[i]);
+        }
+
+        // If no forced passes, solve the entire set directly.
+        if (forcedPasses.Count == 0)
+        {
+            var selected = SolveSubProblem(remainingCandidates);
+            return SortByAos(selected, PassSelectionReason.AlgorithmSelected);
+        }
+
+        // Step 6: Handle forced inclusions.
+        // Sort forced passes by AOS to establish gap intervals.
+        forcedPasses.Sort((a, b) => a.Pass.AosUtc.CompareTo(b.Pass.AosUtc));
+
+        // Remove candidates that overlap with any forced pass.
+        var nonOverlapping = new List<ScoredPass>();
+        for (int i = 0; i < remainingCandidates.Count; i++)
+        {
+            if (!OverlapsAnyForced(remainingCandidates[i], forcedPasses))
+                nonOverlapping.Add(remainingCandidates[i]);
+        }
+
+        // Solve sub-problems in gaps between forced intervals.
+        var result = new List<ScheduledPass>();
+
+        // Add forced passes to result.
+        for (int i = 0; i < forcedPasses.Count; i++)
+        {
+            result.Add(new ScheduledPass
+            {
+                Scored = forcedPasses[i],
+                Reason = PassSelectionReason.ForceIncluded
+            });
+        }
+
+        // Solve the remaining candidates that fit in gaps.
+        if (nonOverlapping.Count > 0)
+        {
+            var gapSelected = SolveSubProblem(nonOverlapping);
+            for (int i = 0; i < gapSelected.Count; i++)
+            {
+                result.Add(new ScheduledPass
+                {
+                    Scored = gapSelected[i],
+                    Reason = PassSelectionReason.AlgorithmSelected
+                });
+            }
+        }
+
+        // Sort final output by AOS time.
+        result.Sort((a, b) => a.Scored.Pass.AosUtc.CompareTo(b.Scored.Pass.AosUtc));
+        return result;
+    }
+
+    /// <summary>
+    /// Solves the weighted interval scheduling problem for a set of candidates
+    /// using dynamic programming with backtracking.
+    /// </summary>
+    private static List<ScoredPass> SolveSubProblem(List<ScoredPass> candidates)
+    {
+        if (candidates.Count == 0)
+            return [];
+
+        // Sort by LOS time (end time).
+        candidates.Sort((a, b) => a.Pass.LosUtc.CompareTo(b.Pass.LosUtc));
+
+        int n = candidates.Count;
+
+        // Compute effective weights with tie-breaking epsilon.
+        var weights = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            weights[i] = candidates[i].CompositeScore
+                         + candidates[i].Pass.MaxElevationDeg * 1e-10;
+        }
+
+        // Compute p[i]: the largest index j < i such that candidates[j] does not overlap candidates[i].
+        // candidates[j].LosUtc <= candidates[i].AosUtc (no overlap means j ends at or before i starts).
+        var p = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            p[i] = FindLatestNonOverlapping(candidates, i);
+        }
+
+        // DP recurrence: dp[i] = max total weight using candidates[0..i].
+        // dp[i] = max(dp[i-1], dp[p[i]] + weights[i])
+        // We use 1-indexed dp where dp[0] = 0 (no candidates selected).
+        var dp = new double[n + 1];
+        dp[0] = 0;
+
+        for (int i = 1; i <= n; i++)
+        {
+            double includeI = weights[i - 1] + dp[p[i - 1] + 1]; // p is 0-indexed returning -1..n-1, shift to dp index
+            double excludeI = dp[i - 1];
+            dp[i] = Math.Max(includeI, excludeI);
+        }
+
+        // Backtrack to recover the selected set.
+        var selected = new List<ScoredPass>();
+        int j = n;
+        while (j > 0)
+        {
+            double includeJ = weights[j - 1] + dp[p[j - 1] + 1];
+            if (includeJ >= dp[j - 1])
+            {
+                selected.Add(candidates[j - 1]);
+                j = p[j - 1] + 1; // jump to the dp index of p[j-1]
+            }
+            else
+            {
+                j--;
+            }
+        }
+
+        return selected;
+    }
+
+    /// <summary>
+    /// Binary search for the largest index j &lt; i such that candidates[j].LosUtc &lt;= candidates[i].AosUtc.
+    /// Returns -1 if no such index exists. Candidates must be sorted by LOS.
+    /// </summary>
+    private static int FindLatestNonOverlapping(List<ScoredPass> candidates, int i)
+    {
+        DateTime target = candidates[i].Pass.AosUtc;
+        int lo = 0;
+        int hi = i - 1;
+        int result = -1;
+
+        while (lo <= hi)
+        {
+            int mid = lo + (hi - lo) / 2;
+            if (candidates[mid].Pass.LosUtc <= target)
+            {
+                result = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Checks whether a candidate pass overlaps any of the forced passes.
+    /// </summary>
+    private static bool OverlapsAnyForced(ScoredPass candidate, List<ScoredPass> forcedPasses)
+    {
+        for (int i = 0; i < forcedPasses.Count; i++)
+        {
+            if (Overlaps(candidate, forcedPasses[i]))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Two passes overlap if their [AOS, LOS] intervals intersect
+    /// (i.e. one starts before the other ends and vice versa).
+    /// Touching boundaries (LOS == AOS) is not considered an overlap.
+    /// </summary>
+    private static bool Overlaps(ScoredPass a, ScoredPass b)
+    {
+        return a.Pass.AosUtc < b.Pass.LosUtc && b.Pass.AosUtc < a.Pass.LosUtc;
+    }
+
+    /// <summary>
+    /// Wraps selected passes as ScheduledPass with the given reason and sorts by AOS.
+    /// </summary>
+    private static IReadOnlyList<ScheduledPass> SortByAos(
+        List<ScoredPass> selected,
+        PassSelectionReason reason)
+    {
+        var result = new List<ScheduledPass>(selected.Count);
+        for (int i = 0; i < selected.Count; i++)
+        {
+            result.Add(new ScheduledPass
+            {
+                Scored = selected[i],
+                Reason = reason
+            });
+        }
+        result.Sort((a, b) => a.Scored.Pass.AosUtc.CompareTo(b.Scored.Pass.AosUtc));
+        return result;
+    }
+}

--- a/OscarWatch.Tests/PlanExecutorPropertyTests.cs
+++ b/OscarWatch.Tests/PlanExecutorPropertyTests.cs
@@ -1,0 +1,252 @@
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for PlanExecutor.
+/// Validates correctness properties 11–12 from the session-planner design document.
+/// </summary>
+public sealed class PlanExecutorPropertyTests
+{
+    // ─── Stub ILiveTrackingService ───────────────────────────────────────────────
+
+    private sealed class StubLiveTrackingService : ILiveTrackingService
+    {
+        public string? FocusedNoradId { get; set; }
+        public DateTime SnapshotUtc => DateTime.MinValue;
+        public TimeSpan MapTimeOffset { get; set; }
+        public DateTime LiveNowSnapshotUtc => DateTime.MinValue;
+        public IReadOnlyList<SatelliteTrackState> GetSnapshot() => [];
+        public IReadOnlyList<SatelliteTrackState> GetLiveNowSnapshot() => [];
+        public void Start() { }
+        public void RequestReload() { }
+        public void Dispose() { }
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static readonly DateTime SessionStart = new(2025, 7, 1, 14, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SessionEnd = new(2025, 7, 1, 20, 0, 0, DateTimeKind.Utc);
+
+    private static ScoredPass CreatePass(int startOffsetMinutes, int durationMinutes, int elevation, int priority, int index)
+    {
+        var aos = SessionStart.AddMinutes(startOffsetMinutes);
+        var los = aos.AddMinutes(durationMinutes);
+        var pass = new PassInfo
+        {
+            SatelliteName = $"SAT-{index}",
+            NoradId = $"{25544 + index}",
+            AosUtc = aos,
+            LosUtc = los,
+            MaxElevationDeg = elevation,
+            MaxElevationUtc = aos.AddMinutes(durationMinutes / 2.0)
+        };
+        var quality = PassQualityScorer.ComputeScore(elevation, durationMinutes, TransponderCategory.Unknown);
+        var composite = PassQualityScorer.ComputeCompositeScore(quality, priority);
+        return new ScoredPass
+        {
+            Pass = pass,
+            QualityScore = quality,
+            SatellitePriority = priority,
+            CompositeScore = composite
+        };
+    }
+
+    /// <summary>
+    /// Builds a list of non-overlapping passes within the session window from seed values.
+    /// Guarantees gaps between passes for pre-alert testing.
+    /// </summary>
+    private static List<ScoredPass> BuildNonOverlappingPasses(int[] seeds, int minGap = 1)
+    {
+        var passes = new List<ScoredPass>();
+        int currentOffset = 0;
+        var sessionMinutes = (int)(SessionEnd - SessionStart).TotalMinutes;
+
+        for (int i = 0; i < seeds.Length; i++)
+        {
+            var seed = Math.Abs(seeds[i]);
+            var durationMinutes = 3 + (seed % 13);       // 3..15 minutes
+            var gap = minGap + ((seed / 13) % 20);       // minGap..minGap+19 minute gap
+            var elevation = 10 + ((seed / 260) % 81);    // 10..90
+            var priority = 1 + ((seed / 21060) % 10);    // 1..10
+
+            var startOffset = currentOffset + gap;
+            if (startOffset + durationMinutes > sessionMinutes)
+                break;
+
+            passes.Add(CreatePass(startOffset, durationMinutes, elevation, priority, i));
+            currentOffset = startOffset + durationMinutes;
+        }
+
+        return passes;
+    }
+
+    private static SessionPlan BuildPlan(List<ScoredPass> passes)
+    {
+        var scheduled = passes.Select(p => new ScheduledPass
+        {
+            Scored = p,
+            Reason = PassSelectionReason.AlgorithmSelected
+        }).ToList();
+
+        return new SessionPlan
+        {
+            SessionStartUtc = SessionStart,
+            SessionEndUtc = SessionEnd,
+            ScheduledPasses = scheduled,
+            AllCandidates = passes,
+            ExcludedIds = new HashSet<string>(),
+            ForcedInclusionIds = new HashSet<string>()
+        };
+    }
+
+    // ─── Property 11: Plan Executor Focus State ──────────────────────────────────
+    // Feature: session-planner, Property 11: Plan Executor Focus State
+    // **Validates: Requirements 7.1, 7.5**
+
+    /// <summary>
+    /// For any session plan and any UTC time within the session window,
+    /// PlanExecutor.Tick(utcNow) SHALL determine the correct focused NORAD ID:
+    /// the NoradId of the pass whose [AOS, LOS] contains utcNow, or during a gap,
+    /// the NoradId of the most recent completed pass.
+    /// </summary>
+    [Property]
+    public bool PlanExecutorFocusState(int[] seeds, byte tickOffsetFraction)
+    {
+        if (seeds == null || seeds.Length < 2)
+            return true;
+
+        var limited = seeds.Take(8).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count < 2)
+            return true;
+
+        var plan = BuildPlan(passes);
+        var stub = new StubLiveTrackingService();
+        using var executor = new PlanExecutor(stub);
+        executor.Start(plan, preAlertMinutes: 2);
+
+        // Pick a pass index to test — we'll test the time at AOS of that pass
+        var passIndex = tickOffsetFraction % passes.Count;
+        var targetPass = passes[passIndex];
+        var utcNow = targetPass.Pass.AosUtc;
+
+        // Tick sequentially from the first pass's AOS to just before our target,
+        // so that the executor builds up its internal state correctly.
+        for (int i = 0; i <= passIndex; i++)
+        {
+            var p = passes[i];
+            // Tick at AOS of each pass
+            executor.Tick(p.Pass.AosUtc);
+            // Tick at LOS of each pass (to mark it completed)
+            if (i < passIndex)
+                executor.Tick(p.Pass.LosUtc.AddSeconds(1));
+        }
+
+        // Verify: at the target pass's AOS time, the focus should be on the target pass's NoradId
+        var expectedNoradId = targetPass.Pass.NoradId;
+        if (stub.FocusedNoradId != expectedNoradId)
+            return false;
+
+        // Now test gap behaviour: tick in the gap after this pass (if not last)
+        if (passIndex < passes.Count - 1)
+        {
+            var gapTime = targetPass.Pass.LosUtc.AddSeconds(5);
+            var nextPassAos = passes[passIndex + 1].Pass.AosUtc;
+
+            // Only test gap if gapTime is actually in the gap
+            if (gapTime < nextPassAos)
+            {
+                executor.Tick(gapTime);
+                // During gap, FocusedNoradId should still be the last completed pass's NoradId
+                if (stub.FocusedNoradId != expectedNoradId)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    // ─── Property 12: Pre-Alert Timing ───────────────────────────────────────────
+    // Feature: session-planner, Property 12: Pre-Alert Timing
+    // **Validates: Requirements 8.1, 8.4**
+
+    /// <summary>
+    /// For any session plan with pre-alert lead time L minutes, for each scheduled pass,
+    /// the pre-alert SHALL fire at max(previousLOS, AOS − L minutes).
+    /// If the gap before the pass is ≥ L, alert at AOS − L; if the gap &lt; L, alert at
+    /// the previous pass's LOS time.
+    /// </summary>
+    [Property]
+    public bool PreAlertTiming(int[] seeds, byte preAlertSeed)
+    {
+        if (seeds == null || seeds.Length < 2)
+            return true;
+
+        var limited = seeds.Take(8).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count < 2)
+            return true;
+
+        // Use a pre-alert lead time between 1 and 15
+        var preAlertMinutes = 1 + (preAlertSeed % 15);
+
+        var plan = BuildPlan(passes);
+        var stub = new StubLiveTrackingService();
+        using var executor = new PlanExecutor(stub);
+        executor.Start(plan, preAlertMinutes: preAlertMinutes);
+
+        // Test pre-alert for the second pass (index 1) — it has a previous pass for gap calculation
+        var targetPassIndex = 1;
+        var targetPass = passes[targetPassIndex];
+        var previousPass = passes[targetPassIndex - 1];
+
+        var aos = targetPass.Pass.AosUtc;
+        var previousLos = previousPass.Pass.LosUtc;
+        var alertLeadTime = TimeSpan.FromMinutes(preAlertMinutes);
+
+        // Expected alert time: max(previousLOS, AOS - L)
+        var aosMinusL = aos - alertLeadTime;
+        var expectedAlertTime = previousLos > aosMinusL ? previousLos : aosMinusL;
+
+        // First, tick at AOS of the first pass so it's tracked
+        executor.Tick(previousPass.Pass.AosUtc);
+
+        // Tick just before the expected alert time — should NOT get a pre-alert for target pass
+        var justBefore = expectedAlertTime.AddSeconds(-1);
+        if (justBefore > previousPass.Pass.AosUtc)
+        {
+            var actionBefore = executor.Tick(justBefore);
+            // If we get a pre-alert for the target pass before the expected time, that's a failure
+            if (actionBefore is PlanExecutorAction.RaisePreAlert alertBefore
+                && alertBefore.SatelliteName == targetPass.Pass.SatelliteName)
+                return false;
+        }
+
+        // Tick at the expected alert time — should get a pre-alert for the target pass
+        var actionAt = executor.Tick(expectedAlertTime);
+        if (actionAt is PlanExecutorAction.RaisePreAlert alertAt)
+        {
+            // The alert should be for our target pass
+            return alertAt.SatelliteName == targetPass.Pass.SatelliteName;
+        }
+
+        // If the alert didn't fire at the expected time, it might be because we already
+        // triggered it (or the first pass's AOS triggered a switch instead).
+        // Try ticking one more second to account for timing
+        var actionAfter = executor.Tick(expectedAlertTime.AddSeconds(1));
+        if (actionAfter is PlanExecutorAction.RaisePreAlert alertAfter)
+        {
+            return alertAfter.SatelliteName == targetPass.Pass.SatelliteName;
+        }
+
+        // The pre-alert should have fired at or very near the expected time
+        return false;
+    }
+}

--- a/OscarWatch.Tests/SessionPlanAdjustmentPropertyTests.cs
+++ b/OscarWatch.Tests/SessionPlanAdjustmentPropertyTests.cs
@@ -1,0 +1,238 @@
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for session plan adjustments.
+/// Validates correctness properties 8–10 from the session-planner design document.
+/// </summary>
+public sealed class SessionPlanAdjustmentPropertyTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static readonly DateTime SessionStart = new(2025, 7, 1, 14, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SessionEnd = new(2025, 7, 1, 20, 0, 0, DateTimeKind.Utc); // 6 hour window
+
+    /// <summary>
+    /// Creates a ScoredPass at a specific offset within the session window.
+    /// </summary>
+    private static ScoredPass CreatePass(int startOffsetMinutes, int durationMinutes, int elevation, int priority, int index)
+    {
+        var aos = SessionStart.AddMinutes(startOffsetMinutes);
+        var los = aos.AddMinutes(durationMinutes);
+        var pass = new PassInfo
+        {
+            SatelliteName = $"SAT-{index}",
+            NoradId = $"{25544 + index}",
+            AosUtc = aos,
+            LosUtc = los,
+            MaxElevationDeg = elevation,
+            MaxElevationUtc = aos.AddMinutes(durationMinutes / 2.0)
+        };
+        var quality = PassQualityScorer.ComputeScore(elevation, durationMinutes, TransponderCategory.Unknown);
+        var composite = PassQualityScorer.ComputeCompositeScore(quality, priority);
+        return new ScoredPass
+        {
+            Pass = pass,
+            QualityScore = quality,
+            SatellitePriority = priority,
+            CompositeScore = composite
+        };
+    }
+
+    /// <summary>
+    /// Builds a list of non-overlapping passes within the session window from seed values.
+    /// Each pass is placed sequentially to guarantee no overlap.
+    /// </summary>
+    private static List<ScoredPass> BuildNonOverlappingPasses(int[] seeds)
+    {
+        var passes = new List<ScoredPass>();
+        int currentOffset = 0;
+        var sessionMinutes = (int)(SessionEnd - SessionStart).TotalMinutes; // 360
+
+        for (int i = 0; i < seeds.Length; i++)
+        {
+            var seed = Math.Abs(seeds[i]);
+            var durationMinutes = 3 + (seed % 13); // 3..15
+            var gap = 1 + ((seed / 13) % 20);      // 1..20 minute gap before this pass
+            var elevation = 10 + ((seed / 260) % 81); // 10..90
+            var priority = 1 + ((seed / 21060) % 10); // 1..10
+
+            var startOffset = currentOffset + gap;
+            if (startOffset + durationMinutes > sessionMinutes)
+                break; // No more room
+
+            passes.Add(CreatePass(startOffset, durationMinutes, elevation, priority, i));
+            currentOffset = startOffset + durationMinutes;
+        }
+
+        return passes;
+    }
+
+    /// <summary>
+    /// Builds a SessionPlan with the given non-overlapping passes as both scheduled and candidates.
+    /// </summary>
+    private static SessionPlan BuildPlan(List<ScoredPass> passes)
+    {
+        var scheduled = passes.Select(p => new ScheduledPass
+        {
+            Scored = p,
+            Reason = PassSelectionReason.AlgorithmSelected
+        }).ToList();
+
+        return new SessionPlan
+        {
+            SessionStartUtc = SessionStart,
+            SessionEndUtc = SessionEnd,
+            ScheduledPasses = scheduled,
+            AllCandidates = passes,
+            ExcludedIds = new HashSet<string>(),
+            ForcedInclusionIds = new HashSet<string>()
+        };
+    }
+
+    // ─── Property 8: Session Time Accounting ─────────────────────────────────────
+    // Feature: session-planner, Property 8: Session Time Accounting
+    // **Validates: Requirements 5.4**
+
+    /// <summary>
+    /// For any session plan, the sum of all scheduled pass durations (total operating time)
+    /// plus the sum of all gap durations (total gap time) SHALL equal the total session duration
+    /// (SessionEndUtc − SessionStartUtc).
+    /// </summary>
+    [Property]
+    public bool SessionTimeAccounting(int[] seeds)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        var limited = seeds.Take(15).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+        var plan = BuildPlan(passes);
+
+        var sessionDuration = plan.SessionEndUtc - plan.SessionStartUtc;
+        var totalOperating = plan.TotalOperatingTime;
+        var totalGap = plan.TotalGapTime;
+
+        // TotalOperatingTime + TotalGapTime == SessionDuration
+        var sum = totalOperating + totalGap;
+        return Math.Abs((sum - sessionDuration).TotalSeconds) < 0.001;
+    }
+
+    // ─── Property 9: Exclusion Respected ─────────────────────────────────────────
+    // Feature: session-planner, Property 9: Exclusion Respected
+    // **Validates: Requirements 6.1, 6.2**
+
+    /// <summary>
+    /// For any session plan and any set of excluded pass IDs, after calling
+    /// WeightedIntervalScheduler.Solve with those exclusions removed from candidates,
+    /// (a) no excluded pass ID SHALL appear in the result, and
+    /// (b) the non-overlap invariant SHALL still hold.
+    /// </summary>
+    [Property]
+    public bool ExclusionRespected(int[] seeds, int exclusionSeed)
+    {
+        if (seeds == null || seeds.Length < 2)
+            return true;
+
+        var limited = seeds.Take(12).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count < 2)
+            return true;
+
+        // Select passes to exclude using the seed
+        var absSeed = Math.Abs(exclusionSeed);
+        var excludeCount = 1 + (absSeed % Math.Min(3, passes.Count));
+        var excludedIds = new HashSet<string>();
+        for (int i = 0; i < excludeCount && i < passes.Count; i++)
+        {
+            var idx = (absSeed / (i + 1)) % passes.Count;
+            excludedIds.Add(passes[idx].Id);
+        }
+
+        // Filter out excluded passes and re-solve (mirrors AdjustPlan logic)
+        var filteredCandidates = passes.Where(c => !excludedIds.Contains(c.Id)).ToList();
+        var result = WeightedIntervalScheduler.Solve(filteredCandidates);
+
+        // (a) No excluded pass ID in result
+        foreach (var sp in result)
+        {
+            if (excludedIds.Contains(sp.Scored.Id))
+                return false;
+        }
+
+        // (b) Non-overlap invariant holds
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            if (result[i].Scored.Pass.LosUtc > result[i + 1].Scored.Pass.AosUtc)
+                return false;
+        }
+
+        return true;
+    }
+
+    // ─── Property 10: Forced Inclusion Respected ─────────────────────────────────
+    // Feature: session-planner, Property 10: Forced Inclusion Respected
+    // **Validates: Requirements 6.3, 6.4**
+
+    /// <summary>
+    /// For any session plan and any set of force-included pass IDs (which themselves
+    /// do not mutually overlap), after calling WeightedIntervalScheduler.Solve with
+    /// those forced inclusions, (a) every forced pass SHALL appear in the result,
+    /// and (b) the non-overlap invariant SHALL still hold.
+    /// </summary>
+    [Property]
+    public bool ForcedInclusionRespected(int[] seeds, int forceSeed)
+    {
+        if (seeds == null || seeds.Length < 2)
+            return true;
+
+        var limited = seeds.Take(12).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count < 2)
+            return true;
+
+        // Select passes to force-include using the seed.
+        // Since our passes are already non-overlapping, any subset is valid for forced inclusion.
+        var absSeed = Math.Abs(forceSeed);
+        var forceCount = 1 + (absSeed % Math.Min(3, passes.Count));
+        var forcedIds = new HashSet<string>();
+        var forcedIndices = new HashSet<int>();
+        for (int i = 0; i < forceCount; i++)
+        {
+            var idx = (absSeed / (i + 1)) % passes.Count;
+            if (!forcedIndices.Contains(idx))
+            {
+                forcedIndices.Add(idx);
+                forcedIds.Add(passes[idx].Id);
+            }
+        }
+
+        if (forcedIds.Count == 0)
+            return true;
+
+        var result = WeightedIntervalScheduler.Solve(passes, forcedInclusionIds: forcedIds);
+
+        // (a) Every forced pass appears in result
+        var resultIds = result.Select(sp => sp.Scored.Id).ToHashSet();
+        foreach (var fid in forcedIds)
+        {
+            if (!resultIds.Contains(fid))
+                return false;
+        }
+
+        // (b) Non-overlap invariant holds
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            if (result[i].Scored.Pass.LosUtc > result[i + 1].Scored.Pass.AosUtc)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/OscarWatch.Tests/SessionPlanExportPropertyTests.cs
+++ b/OscarWatch.Tests/SessionPlanExportPropertyTests.cs
@@ -1,0 +1,229 @@
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Export;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for session plan export (CSV and ICS).
+/// Validates correctness properties 16–17 from the session-planner design document.
+/// </summary>
+public sealed class SessionPlanExportPropertyTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static readonly DateTime SessionStart = new(2025, 7, 1, 14, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SessionEnd = new(2025, 7, 1, 20, 0, 0, DateTimeKind.Utc);
+
+    private static readonly GroundStation TestStation = new()
+    {
+        DisplayName = "TestStation",
+        GridSquare = "IO91wm",
+        LatitudeDeg = 51.5,
+        LongitudeDeg = -0.1
+    };
+
+    /// <summary>
+    /// Builds a list of non-overlapping passes within the session window from seed values.
+    /// Each pass is placed sequentially to guarantee no overlap.
+    /// </summary>
+    private static List<ScoredPass> BuildNonOverlappingPasses(int[] seeds)
+    {
+        var passes = new List<ScoredPass>();
+        int currentOffset = 0;
+        var sessionMinutes = (int)(SessionEnd - SessionStart).TotalMinutes; // 360
+
+        for (int i = 0; i < seeds.Length; i++)
+        {
+            var seed = Math.Abs(seeds[i]);
+            var durationMinutes = 3 + (seed % 13); // 3..15
+            var gap = 1 + ((seed / 13) % 20);      // 1..20 minute gap before this pass
+            var elevation = 10 + ((seed / 260) % 81); // 10..90
+            var priority = 1 + ((seed / 21060) % 10); // 1..10
+
+            var startOffset = currentOffset + gap;
+            if (startOffset + durationMinutes > sessionMinutes)
+                break; // No more room
+
+            var aos = SessionStart.AddMinutes(startOffset);
+            var los = aos.AddMinutes(durationMinutes);
+            var pass = new PassInfo
+            {
+                SatelliteName = $"SAT-{i}",
+                NoradId = $"{25544 + i}",
+                AosUtc = aos,
+                LosUtc = los,
+                MaxElevationDeg = elevation,
+                MaxElevationUtc = aos.AddMinutes(durationMinutes / 2.0)
+            };
+            var quality = PassQualityScorer.ComputeScore(elevation, durationMinutes, TransponderCategory.Unknown);
+            var composite = PassQualityScorer.ComputeCompositeScore(quality, priority);
+            passes.Add(new ScoredPass
+            {
+                Pass = pass,
+                QualityScore = quality,
+                SatellitePriority = priority,
+                CompositeScore = composite
+            });
+            currentOffset = startOffset + durationMinutes;
+        }
+
+        return passes;
+    }
+
+    /// <summary>
+    /// Builds a SessionPlan with the given non-overlapping passes.
+    /// </summary>
+    private static SessionPlan BuildPlan(List<ScoredPass> passes)
+    {
+        var scheduled = passes.Select(p => new ScheduledPass
+        {
+            Scored = p,
+            Reason = PassSelectionReason.AlgorithmSelected
+        }).ToList();
+
+        return new SessionPlan
+        {
+            SessionStartUtc = SessionStart,
+            SessionEndUtc = SessionEnd,
+            ScheduledPasses = scheduled,
+            AllCandidates = passes,
+            ExcludedIds = new HashSet<string>(),
+            ForcedInclusionIds = new HashSet<string>()
+        };
+    }
+
+    // ─── Property 16: ICS Export Structure ───────────────────────────────────────
+    // Feature: session-planner, Property 16: ICS Export Structure
+    // **Validates: Requirements 10.2, 10.3**
+
+    /// <summary>
+    /// For any session plan with N scheduled passes and pre-alert lead time L,
+    /// SessionPlanExporter.BuildCalendar SHALL produce output containing exactly N
+    /// VEVENT blocks, each with a VALARM whose TRIGGER is -PT{L}M, and DTSTART/DTEND
+    /// matching the pass's AOS/LOS in UTC format (yyyyMMddTHHmmssZ).
+    /// </summary>
+    [Property]
+    public bool IcsExportStructure(int[] seeds, PositiveInt preAlertMinutesRaw)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        var limited = seeds.Take(15).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count == 0)
+            return true;
+
+        var plan = BuildPlan(passes);
+        var preAlertMinutes = 1 + (preAlertMinutesRaw.Get % 15); // 1..15
+
+        var ics = SessionPlanExporter.BuildCalendar(plan, TestStation, preAlertMinutes);
+
+        // Count VEVENT blocks
+        var veventCount = CountOccurrences(ics, "BEGIN:VEVENT");
+        if (veventCount != passes.Count)
+            return false;
+
+        // Verify each pass has correct DTSTART, DTEND, and VALARM TRIGGER
+        for (int i = 0; i < passes.Count; i++)
+        {
+            var pass = passes[i].Pass;
+            var expectedDtStart = $"DTSTART:{pass.AosUtc.ToString("yyyyMMdd'T'HHmmss'Z'")}";
+            var expectedDtEnd = $"DTEND:{pass.LosUtc.ToString("yyyyMMdd'T'HHmmss'Z'")}";
+            var expectedTrigger = $"TRIGGER:-PT{preAlertMinutes}M";
+
+            if (!ics.Contains(expectedDtStart))
+                return false;
+            if (!ics.Contains(expectedDtEnd))
+                return false;
+            if (CountOccurrences(ics, expectedTrigger) != passes.Count)
+                return false;
+        }
+
+        // Verify each VEVENT has a VALARM block
+        var valarmCount = CountOccurrences(ics, "BEGIN:VALARM");
+        if (valarmCount != passes.Count)
+            return false;
+
+        return true;
+    }
+
+    // ─── Property 17: CSV Export Completeness ────────────────────────────────────
+    // Feature: session-planner, Property 17: CSV Export Completeness
+    // **Validates: Requirements 10.1**
+
+    /// <summary>
+    /// For any session plan with N scheduled passes, SessionPlanExporter.BuildCsv SHALL
+    /// produce output with exactly N+1 lines (header + N data rows), and each row SHALL
+    /// contain values for SatelliteName, NoradId, AOS_UTC, LOS_UTC, MaxElevationDeg,
+    /// CompositeScore, and Status.
+    /// </summary>
+    [Property]
+    public bool CsvExportCompleteness(int[] seeds)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        var limited = seeds.Take(15).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count == 0)
+            return true;
+
+        var plan = BuildPlan(passes);
+        var csv = SessionPlanExporter.BuildCsv(plan);
+
+        // Split into lines, removing any trailing empty line from final newline
+        var lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                       .Select(l => l.TrimEnd('\r'))
+                       .Where(l => !string.IsNullOrWhiteSpace(l))
+                       .ToArray();
+
+        // Exactly N+1 lines (header + N data rows)
+        if (lines.Length != passes.Count + 1)
+            return false;
+
+        // Verify header contains all required columns
+        var header = lines[0];
+        var requiredColumns = new[] { "SatelliteName", "NoradId", "AOS_UTC", "LOS_UTC", "MaxElevationDeg", "CompositeScore", "Status" };
+        foreach (var col in requiredColumns)
+        {
+            if (!header.Contains(col))
+                return false;
+        }
+
+        // Verify each data row has 7 comma-separated values
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var fields = lines[i].Split(',');
+            if (fields.Length != 7)
+                return false;
+
+            // Each field should be non-empty
+            foreach (var field in fields)
+            {
+                if (string.IsNullOrWhiteSpace(field))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    // ─── Utility ─────────────────────────────────────────────────────────────────
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/OscarWatch.Tests/SessionPlanPersistencePropertyTests.cs
+++ b/OscarWatch.Tests/SessionPlanPersistencePropertyTests.cs
@@ -1,0 +1,192 @@
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for session plan serialisation round-trip.
+/// Validates correctness property 15 from the session-planner design document.
+/// </summary>
+public sealed class SessionPlanPersistencePropertyTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static readonly DateTime SessionStart = new(2025, 7, 1, 14, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SessionEnd = new(2025, 7, 1, 20, 0, 0, DateTimeKind.Utc); // 6 hour window
+
+    /// <summary>
+    /// Creates a ScoredPass at a specific offset within the session window.
+    /// </summary>
+    private static ScoredPass CreatePass(int startOffsetMinutes, int durationMinutes, int elevation, int priority, int index)
+    {
+        var aos = SessionStart.AddMinutes(startOffsetMinutes);
+        var los = aos.AddMinutes(durationMinutes);
+        var pass = new PassInfo
+        {
+            SatelliteName = $"SAT-{index}",
+            NoradId = $"{25544 + index}",
+            AosUtc = aos,
+            LosUtc = los,
+            MaxElevationDeg = elevation,
+            MaxElevationUtc = aos.AddMinutes(durationMinutes / 2.0)
+        };
+        var quality = PassQualityScorer.ComputeScore(elevation, durationMinutes, TransponderCategory.Unknown);
+        var composite = PassQualityScorer.ComputeCompositeScore(quality, priority);
+        return new ScoredPass
+        {
+            Pass = pass,
+            QualityScore = quality,
+            SatellitePriority = priority,
+            CompositeScore = composite
+        };
+    }
+
+    /// <summary>
+    /// Builds a list of non-overlapping passes within the session window from seed values.
+    /// Each pass is placed sequentially to guarantee no overlap.
+    /// </summary>
+    private static List<ScoredPass> BuildNonOverlappingPasses(int[] seeds)
+    {
+        var passes = new List<ScoredPass>();
+        int currentOffset = 0;
+        var sessionMinutes = (int)(SessionEnd - SessionStart).TotalMinutes; // 360
+
+        for (int i = 0; i < seeds.Length; i++)
+        {
+            var seed = Math.Abs(seeds[i]);
+            var durationMinutes = 3 + (seed % 13); // 3..15
+            var gap = 1 + ((seed / 13) % 20);      // 1..20 minute gap before this pass
+            var elevation = 10 + ((seed / 260) % 81); // 10..90
+            var priority = 1 + ((seed / 21060) % 10); // 1..10
+
+            var startOffset = currentOffset + gap;
+            if (startOffset + durationMinutes > sessionMinutes)
+                break; // No more room
+
+            passes.Add(CreatePass(startOffset, durationMinutes, elevation, priority, i));
+            currentOffset = startOffset + durationMinutes;
+        }
+
+        return passes;
+    }
+
+    /// <summary>
+    /// Generates a set of pass IDs from a subset of available passes using a seed.
+    /// </summary>
+    private static HashSet<string> GenerateIdSubset(List<ScoredPass> passes, int seed, int maxCount)
+    {
+        var ids = new HashSet<string>();
+        if (passes.Count == 0) return ids;
+
+        var absSeed = Math.Abs(seed);
+        var count = absSeed % (maxCount + 1); // 0..maxCount
+
+        for (int i = 0; i < count && i < passes.Count; i++)
+        {
+            var idx = (absSeed / (i + 1)) % passes.Count;
+            ids.Add(passes[idx].Id);
+        }
+
+        return ids;
+    }
+
+    // ─── Property 15: Serialisation Round-Trip ───────────────────────────────────
+    // Feature: session-planner, Property 15: Serialisation Round-Trip
+    // **Validates: Requirements 12.1, 12.3**
+
+    /// <summary>
+    /// For any valid SessionPlan (with scheduled passes, exclusions, and forced inclusions),
+    /// serialising to JSON and then deserialising SHALL produce an equivalent plan with
+    /// identical session bounds, pass data, scores, reasons, and adjustment sets.
+    /// </summary>
+    [Property]
+    public bool SerialisationRoundTrip(int[] seeds, int excludeSeed, int forceSeed)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        // Limit to 1-10 passes
+        var limited = seeds.Take(10).ToArray();
+        var passes = BuildNonOverlappingPasses(limited);
+
+        if (passes.Count == 0)
+            return true;
+
+        // Build scheduled passes with mixed reasons
+        var scheduled = passes.Select((p, idx) => new ScheduledPass
+        {
+            Scored = p,
+            Reason = idx % 3 == 0 ? PassSelectionReason.ForceIncluded : PassSelectionReason.AlgorithmSelected
+        }).ToList();
+
+        // Generate random exclusion and forced inclusion ID sets
+        var excludedIds = GenerateIdSubset(passes, excludeSeed, 3);
+        var forcedInclusionIds = GenerateIdSubset(passes, forceSeed, 3);
+
+        var originalPlan = new SessionPlan
+        {
+            SessionStartUtc = SessionStart,
+            SessionEndUtc = SessionEnd,
+            ScheduledPasses = scheduled,
+            AllCandidates = passes,
+            ExcludedIds = excludedIds,
+            ForcedInclusionIds = forcedInclusionIds
+        };
+
+        // Serialise → Deserialise
+        var json = SessionPlanPersistence.Serialise(originalPlan);
+        var restored = SessionPlanPersistence.Deserialise(json);
+
+        // Assert result is not null
+        if (restored is null)
+            return false;
+
+        // Assert session bounds match
+        if (restored.SessionStartUtc != originalPlan.SessionStartUtc)
+            return false;
+        if (restored.SessionEndUtc != originalPlan.SessionEndUtc)
+            return false;
+
+        // Assert scheduled passes count matches
+        if (restored.ScheduledPasses.Count != originalPlan.ScheduledPasses.Count)
+            return false;
+
+        // Assert each scheduled pass matches
+        for (int i = 0; i < originalPlan.ScheduledPasses.Count; i++)
+        {
+            var orig = originalPlan.ScheduledPasses[i];
+            var rest = restored.ScheduledPasses[i];
+
+            if (rest.Scored.Pass.SatelliteName != orig.Scored.Pass.SatelliteName)
+                return false;
+            if (rest.Scored.Pass.NoradId != orig.Scored.Pass.NoradId)
+                return false;
+            if (rest.Scored.Pass.AosUtc != orig.Scored.Pass.AosUtc)
+                return false;
+            if (rest.Scored.Pass.LosUtc != orig.Scored.Pass.LosUtc)
+                return false;
+            if (Math.Abs(rest.Scored.Pass.MaxElevationDeg - orig.Scored.Pass.MaxElevationDeg) > 0.001)
+                return false;
+            if (Math.Abs(rest.Scored.QualityScore - orig.Scored.QualityScore) > 0.0001)
+                return false;
+            if (Math.Abs(rest.Scored.CompositeScore - orig.Scored.CompositeScore) > 0.0001)
+                return false;
+            if (rest.Scored.SatellitePriority != orig.Scored.SatellitePriority)
+                return false;
+            if (rest.Reason != orig.Reason)
+                return false;
+        }
+
+        // Assert ExcludedIds match
+        if (!restored.ExcludedIds.SetEquals(originalPlan.ExcludedIds))
+            return false;
+
+        // Assert ForcedInclusionIds match
+        if (!restored.ForcedInclusionIds.SetEquals(originalPlan.ForcedInclusionIds))
+            return false;
+
+        return true;
+    }
+}

--- a/OscarWatch.Tests/SessionPlannerScoringPropertyTests.cs
+++ b/OscarWatch.Tests/SessionPlannerScoringPropertyTests.cs
@@ -1,0 +1,64 @@
+using FsCheck.Xunit;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// **Validates: Requirements 2.1, 2.2, 2.5**
+///
+/// Property-based tests verifying that <see cref="PassQualityScorer.ComputeScore"/>
+/// always returns a value in the closed interval [0.0, 1.0], regardless of input values.
+/// </summary>
+public sealed class SessionPlannerScoringPropertyTests
+{
+    // Feature: session-planner, Property 1: Score Bounded in [0, 1]
+    // **Validates: Requirements 2.1, 2.2, 2.5**
+
+    /// <summary>
+    /// For any maxElevationDeg (any double), durationMinutes (any double), and
+    /// TransponderCategory value, ComputeScore SHALL return a value in [0.0, 1.0].
+    /// Even for extreme inputs (negative elevation, very large duration, etc.)
+    /// the score must stay within bounds due to clamping.
+    /// </summary>
+    [Property]
+    public bool ScoreIsBoundedBetweenZeroAndOne(double elevation, double duration, int categorySeed)
+    {
+        var categories = (TransponderCategory[])typeof(TransponderCategory).GetEnumValues();
+        var category = categories[((categorySeed % categories.Length) + categories.Length) % categories.Length];
+
+        var score = PassQualityScorer.ComputeScore(elevation, duration, category);
+
+        return score >= 0.0 && score <= 1.0;
+    }
+
+    // Feature: session-planner, Property 2: Composite Score Formula
+    // **Validates: Requirements 3.4**
+
+    /// <summary>
+    /// For any quality score q in [0.0, 1.0] and satellite priority p in [1, 10],
+    /// the composite score SHALL equal q × (11 − p), yielding a value in [0.0, 10.0].
+    /// </summary>
+    [Property]
+    public bool CompositeScoreFollowsFormula(double rawQ, int rawP)
+    {
+        // Constrain q to [0, 1] by normalising via modular arithmetic on the absolute value
+        var q = Math.Abs(rawQ % 1.0);
+        if (double.IsNaN(q) || double.IsInfinity(q))
+            q = 0.5;
+
+        // Constrain p to [1, 10]
+        var p = (((rawP % 10) + 10) % 10) + 1; // yields 1..10
+
+        // Call the production formula
+        var composite = PassQualityScorer.ComputeCompositeScore(q, p);
+
+        // Verify the formula: composite = q * (11 - p)
+        var expected = q * (11 - p);
+        var formulaCorrect = Math.Abs(composite - expected) < 1e-10;
+
+        // Verify the result is within [0.0, 10.0]
+        var inRange = composite >= 0.0 && composite <= 10.0;
+
+        return formulaCorrect && inRange;
+    }
+}

--- a/OscarWatch.Tests/SessionPlannerViewModelTests.cs
+++ b/OscarWatch.Tests/SessionPlannerViewModelTests.cs
@@ -1,0 +1,174 @@
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+using OscarWatch.Core.SessionPlanner;
+using OscarWatch.Localization;
+using OscarWatch.ViewModels;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Unit tests for SessionPlannerViewModel state transitions.
+/// Uses minimal stubs — tests focus on wiring and state machine logic.
+/// </summary>
+public sealed class SessionPlannerViewModelTests
+{
+    // ─── Stubs ───────────────────────────────────────────────────────────────────
+
+    private sealed class StubLiveTrackingService : ILiveTrackingService
+    {
+        public string? FocusedNoradId { get; set; }
+        public DateTime SnapshotUtc => DateTime.MinValue;
+        public TimeSpan MapTimeOffset { get; set; }
+        public DateTime LiveNowSnapshotUtc => DateTime.MinValue;
+        public IReadOnlyList<SatelliteTrackState> GetSnapshot() => [];
+        public IReadOnlyList<SatelliteTrackState> GetLiveNowSnapshot() => [];
+        public void Start() { }
+        public void RequestReload() { }
+        public void Dispose() { }
+    }
+
+    private sealed class StubSettingsService : ISettingsService
+    {
+        public AppSettings Current { get; } = new();
+        public string SettingsPath => "";
+        public string SerializeCurrent() => "";
+        public Task ReplaceAndSaveAsync(AppSettings imported, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void Load() { }
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SaveAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void RequestSave() { }
+        public Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void SyncGridFromLatLon() { }
+        public void SyncLatLonFromGrid() { }
+        public void EnsureSavedStations() { }
+        public void ApplyActiveStation() { }
+        public void SyncActiveStationFromGroundStation() { }
+    }
+
+    private sealed class StubLocalizationService : ILocalizationService
+    {
+        public string Get(string key) => key;
+        public string Get(string key, params object[] args) => key;
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static SessionPlannerViewModel CreateViewModel(out PlanExecutor executor)
+    {
+        var liveTracking = new StubLiveTrackingService();
+        executor = new PlanExecutor(liveTracking);
+        var settings = new StubSettingsService();
+        var localization = new StubLocalizationService();
+
+        // SessionPlannerService is not needed for state transition tests — pass null via reflection workaround.
+        // The ViewModel constructor requires it but we won't call GeneratePlanAsync.
+        var vm = new SessionPlannerViewModel(null!, executor, settings, localization);
+        vm.Initialize();
+        return vm;
+    }
+
+    private static SessionPlan BuildPastPlan()
+    {
+        var yesterday = DateTime.UtcNow.AddDays(-1);
+        var sessionStart = yesterday;
+        var sessionEnd = yesterday.AddHours(2);
+
+        var pass = new PassInfo
+        {
+            SatelliteName = "ISS",
+            NoradId = "25544",
+            AosUtc = yesterday.AddMinutes(10),
+            LosUtc = yesterday.AddMinutes(20),
+            MaxElevationDeg = 45.0,
+            MaxElevationUtc = yesterday.AddMinutes(15)
+        };
+
+        var scored = new ScoredPass
+        {
+            Pass = pass,
+            QualityScore = 0.8,
+            SatellitePriority = 1,
+            CompositeScore = 8.0
+        };
+
+        var scheduled = new ScheduledPass
+        {
+            Scored = scored,
+            Reason = PassSelectionReason.AlgorithmSelected
+        };
+
+        return new SessionPlan
+        {
+            SessionStartUtc = sessionStart,
+            SessionEndUtc = sessionEnd,
+            ScheduledPasses = [scheduled],
+            AllCandidates = [scored],
+            ExcludedIds = new HashSet<string>(),
+            ForcedInclusionIds = new HashSet<string>()
+        };
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void StartExecution_ThenPause_SetsStateToPaused()
+    {
+        var vm = CreateViewModel(out _);
+        vm.ActivePlan = BuildPastPlan(); // Need an active plan; use a plan (review-only flag irrelevant here)
+
+        // Override IsReviewOnly so StartExecution doesn't bail out
+        vm.IsReviewOnly = false;
+
+        vm.StartExecutionCommand.Execute(null);
+        Assert.Equal(PlanExecutionState.Running, vm.ExecutionState);
+
+        vm.PauseExecutionCommand.Execute(null);
+        Assert.Equal(PlanExecutionState.Paused, vm.ExecutionState);
+    }
+
+    [Fact]
+    public void Pause_ThenResume_SetsStateBackToRunning()
+    {
+        var vm = CreateViewModel(out _);
+        vm.ActivePlan = BuildPastPlan();
+        vm.IsReviewOnly = false;
+
+        vm.StartExecutionCommand.Execute(null);
+        vm.PauseExecutionCommand.Execute(null);
+        Assert.Equal(PlanExecutionState.Paused, vm.ExecutionState);
+
+        vm.ResumeExecutionCommand.Execute(null);
+        Assert.Equal(PlanExecutionState.Running, vm.ExecutionState);
+    }
+
+    [Fact]
+    public void PlanWithPastPass_AfterTick_StateBecomesCompleted()
+    {
+        var vm = CreateViewModel(out _);
+        var plan = BuildPastPlan();
+        vm.ActivePlan = plan;
+        vm.IsReviewOnly = false;
+
+        vm.StartExecutionCommand.Execute(null);
+        Assert.Equal(PlanExecutionState.Running, vm.ExecutionState);
+
+        // Tick via ViewModel — since the only pass's LOS is in the past,
+        // the executor will transition to Completed and the ViewModel syncs state.
+        vm.Tick();
+
+        Assert.Equal(PlanExecutionState.Completed, vm.ExecutionState);
+    }
+
+    [Fact]
+    public void LoadPlan_WithPastSessionWindow_SetsIsReviewOnlyTrue()
+    {
+        var vm = CreateViewModel(out _);
+        var pastPlan = BuildPastPlan();
+
+        // Serialize then load via the LoadPlan command (simulates file load)
+        var json = SessionPlanPersistence.Serialise(pastPlan);
+        vm.LoadPlanCommand.Execute(json);
+
+        Assert.True(vm.IsReviewOnly);
+    }
+}

--- a/OscarWatch.Tests/SessionValidationPropertyTests.cs
+++ b/OscarWatch.Tests/SessionValidationPropertyTests.cs
@@ -1,0 +1,129 @@
+using FsCheck;
+using FsCheck.Xunit;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for session validation logic.
+/// Validates correctness properties 13–14 from the session-planner design document.
+/// </summary>
+public sealed class SessionValidationPropertyTests
+{
+    // ─── Property 13: 15-Minute Rounding ─────────────────────────────────────────
+    // Feature: session-planner, Property 13: 15-Minute Rounding
+    // **Validates: Requirements 1.5**
+
+    /// <summary>
+    /// For any DateTime value, RoundUpTo15Minutes SHALL produce a result where
+    /// (a) minutes are divisible by 15 and seconds are zero,
+    /// (b) the result is >= the input, and
+    /// (c) the result is at most 15 minutes after the input.
+    /// </summary>
+    [Property]
+    public bool FifteenMinuteRounding(long ticks)
+    {
+        // Constrain ticks to a valid DateTime range (year 2020-2030)
+        var minTicks = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var maxTicks = new DateTime(2030, 12, 31, 23, 59, 59, DateTimeKind.Utc).Ticks;
+        var range = maxTicks - minTicks;
+        var constrainedTicks = minTicks + (((ticks % range) + range) % range);
+
+        var input = new DateTime(constrainedTicks, DateTimeKind.Utc);
+        var result = SessionPlannerService.RoundUpTo15Minutes(input);
+
+        // (a) Minutes divisible by 15 and seconds are zero
+        if (result.Minute % 15 != 0)
+            return false;
+        if (result.Second != 0)
+            return false;
+
+        // (b) Result >= input
+        if (result < input)
+            return false;
+
+        // (c) Result is at most 15 minutes after input
+        var diff = result - input;
+        if (diff > TimeSpan.FromMinutes(15))
+            return false;
+
+        return true;
+    }
+
+    // ─── Property 14: Session Validation Rejects Invalid Windows ──────────────────
+    // Feature: session-planner, Property 14: Session Validation Rejects Invalid Windows
+    // **Validates: Requirements 1.3, 1.4**
+
+    /// <summary>
+    /// For any pair of DateTimes where end &lt;= start, calling GeneratePlanAsync
+    /// SHALL throw ArgumentException. Test by constructing a service with null
+    /// dependencies — validation runs before any service access.
+    /// </summary>
+    [Property]
+    public bool ValidationRejectsEndBeforeOrEqualStart(long startTicks, int offsetMinutes)
+    {
+        // Constrain start to valid range
+        var minTicks = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var maxTicks = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var range = maxTicks - minTicks;
+        var constrainedTicks = minTicks + (((startTicks % range) + range) % range);
+
+        var start = new DateTime(constrainedTicks, DateTimeKind.Utc);
+
+        // Make end <= start: subtract a non-negative offset (0 means equal)
+        var absOffset = ((offsetMinutes % 1440) + 1440) % 1440; // 0..1439 minutes
+        var end = start.AddMinutes(-absOffset);
+
+        // end <= start should cause ArgumentException
+        try
+        {
+            // Create service with null dependencies — validation fires before any access
+            var service = new SessionPlannerService(null!, null!, null!);
+            service.GeneratePlanAsync(start, end).GetAwaiter().GetResult();
+            return false; // Should have thrown
+        }
+        catch (ArgumentException)
+        {
+            return true; // Expected
+        }
+        catch
+        {
+            return false; // Unexpected exception type
+        }
+    }
+
+    /// <summary>
+    /// For any pair of DateTimes where the duration exceeds 48 hours, calling
+    /// GeneratePlanAsync SHALL throw ArgumentException.
+    /// </summary>
+    [Property]
+    public bool ValidationRejectsDurationOver48Hours(long startTicks, int extraHours)
+    {
+        // Constrain start to valid range
+        var minTicks = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var maxTicks = new DateTime(2029, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var range = maxTicks - minTicks;
+        var constrainedTicks = minTicks + (((startTicks % range) + range) % range);
+
+        var start = new DateTime(constrainedTicks, DateTimeKind.Utc);
+
+        // Duration > 48 hours: add 48 hours plus at least 1 extra minute
+        var extraMinutes = 1 + (((extraHours % 2880) + 2880) % 2880); // 1..2880 extra minutes
+        var end = start.AddHours(48).AddMinutes(extraMinutes);
+
+        try
+        {
+            var service = new SessionPlannerService(null!, null!, null!);
+            service.GeneratePlanAsync(start, end).GetAwaiter().GetResult();
+            return false; // Should have thrown
+        }
+        catch (ArgumentException)
+        {
+            return true; // Expected
+        }
+        catch
+        {
+            return false; // Unexpected exception type
+        }
+    }
+}

--- a/OscarWatch.Tests/WeightedIntervalSchedulerPropertyTests.cs
+++ b/OscarWatch.Tests/WeightedIntervalSchedulerPropertyTests.cs
@@ -1,0 +1,296 @@
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.SessionPlanner;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Property-based tests for <see cref="WeightedIntervalScheduler"/>.
+/// Validates correctness properties 3–7 from the session-planner design document.
+/// </summary>
+public sealed class WeightedIntervalSchedulerPropertyTests
+{
+    // ─── Custom Arbitrary Provider ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a ScoredPass from integer seeds for property-based testing.
+    /// </summary>
+    private static ScoredPass CreateScoredPass(
+        int startMinutes, int durationMinutes, int elevation, int priority, string noradId, string name)
+    {
+        var baseTime = new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var aos = baseTime.AddMinutes(startMinutes);
+        var los = aos.AddMinutes(durationMinutes);
+        var pass = new PassInfo
+        {
+            SatelliteName = name,
+            NoradId = noradId,
+            AosUtc = aos,
+            LosUtc = los,
+            MaxElevationDeg = elevation,
+            MaxElevationUtc = aos.AddMinutes(durationMinutes / 2.0)
+        };
+        var quality = PassQualityScorer.ComputeScore(elevation, durationMinutes, TransponderCategory.Unknown);
+        var composite = PassQualityScorer.ComputeCompositeScore(quality, priority);
+        return new ScoredPass
+        {
+            Pass = pass,
+            QualityScore = quality,
+            SatellitePriority = priority,
+            CompositeScore = composite
+        };
+    }
+
+    /// <summary>
+    /// Builds a list of ScoredPass from arrays of seed values.
+    /// Each pass gets unique start time offsets to create variety.
+    /// </summary>
+    private static List<ScoredPass> BuildCandidates(int[] seeds)
+    {
+        var candidates = new List<ScoredPass>();
+        for (int i = 0; i < seeds.Length; i++)
+        {
+            var seed = Math.Abs(seeds[i]);
+            var startMinutes = (seed % 1440);
+            var durationMinutes = 2 + (seed / 1440 % 14); // 2..15
+            var elevation = 5 + (seed / 20160 % 86);       // 5..90
+            var priority = 1 + (seed / 1733760 % 10);      // 1..10
+            var noradId = $"{25544 + (i % 1000)}";
+            var name = $"SAT-{i}";
+            candidates.Add(CreateScoredPass(startMinutes, durationMinutes, elevation, priority, noradId, name));
+        }
+        return candidates;
+    }
+
+    // ─── Property 3: Non-Overlap Invariant ───────────────────────────────────────
+    // Feature: session-planner, Property 3: Non-Overlap Invariant
+    // **Validates: Requirements 4.1, 4.6**
+
+    /// <summary>
+    /// For any set of candidate ScoredPass values, the output of
+    /// WeightedIntervalScheduler.Solve SHALL contain no two passes whose
+    /// [AOS, LOS] intervals overlap — i.e., for every pair of selected passes
+    /// A and B where A.AosUtc &lt; B.AosUtc, it must hold that A.LosUtc &lt;= B.AosUtc.
+    /// </summary>
+    [Property]
+    public bool NonOverlapInvariant(int[] seeds)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        // Limit to reasonable size
+        var limited = seeds.Take(20).ToArray();
+        var candidates = BuildCandidates(limited);
+
+        var result = WeightedIntervalScheduler.Solve(candidates);
+
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            var a = result[i].Scored.Pass;
+            var b = result[i + 1].Scored.Pass;
+
+            if (a.LosUtc > b.AosUtc)
+                return false;
+        }
+
+        return true;
+    }
+
+    // ─── Property 4: Optimality (Small Inputs) ──────────────────────────────────
+    // Feature: session-planner, Property 4: Optimality (Small Inputs)
+    // **Validates: Requirements 4.2**
+
+    /// <summary>
+    /// For any set of up to 8 candidate passes, the total composite score of the
+    /// solution returned by Solve SHALL be >= the total composite score of every
+    /// other valid (non-overlapping) subset of those candidates.
+    /// Brute-force all 2^n subsets to verify.
+    /// </summary>
+    [Property]
+    public bool OptimalitySmallInputs(int[] seeds)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        // Limit to 8 for brute-force feasibility
+        var limited = seeds.Take(8).ToArray();
+        var candidates = BuildCandidates(limited);
+
+        if (candidates.Count == 0)
+            return true;
+
+        var result = WeightedIntervalScheduler.Solve(candidates);
+        var solverScore = result.Sum(sp => sp.Scored.CompositeScore);
+
+        // Brute-force: enumerate all 2^n subsets
+        int n = candidates.Count;
+        double bestValidScore = 0.0;
+
+        for (long mask = 0; mask < (1L << n); mask++)
+        {
+            var subset = new List<ScoredPass>();
+            for (int i = 0; i < n; i++)
+            {
+                if ((mask & (1L << i)) != 0)
+                    subset.Add(candidates[i]);
+            }
+
+            // Check validity: non-overlapping
+            if (!IsNonOverlapping(subset))
+                continue;
+
+            var subsetScore = subset.Sum(sp => sp.CompositeScore);
+            if (subsetScore > bestValidScore)
+                bestValidScore = subsetScore;
+        }
+
+        // Solver score should be >= best valid score (accounting for floating-point)
+        return solverScore >= bestValidScore - 1e-9;
+    }
+
+    /// <summary>
+    /// Checks whether a set of passes are all pairwise non-overlapping.
+    /// </summary>
+    private static bool IsNonOverlapping(List<ScoredPass> passes)
+    {
+        if (passes.Count <= 1)
+            return true;
+
+        var sorted = passes.OrderBy(p => p.Pass.AosUtc).ToList();
+        for (int i = 0; i < sorted.Count - 1; i++)
+        {
+            if (sorted[i].Pass.LosUtc > sorted[i + 1].Pass.AosUtc)
+                return false;
+        }
+
+        return true;
+    }
+
+    // ─── Property 5: Elevation Threshold Filtering ───────────────────────────────
+    // Feature: session-planner, Property 5: Elevation Threshold Filtering
+    // **Validates: Requirements 4.3**
+
+    /// <summary>
+    /// For any set of candidate passes and minimum elevation threshold,
+    /// no pass in the scheduler output SHALL have MaxElevationDeg below the threshold.
+    /// </summary>
+    [Property]
+    public bool ElevationThresholdFiltering(int[] seeds, int rawThreshold)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        var limited = seeds.Take(15).ToArray();
+        var candidates = BuildCandidates(limited);
+
+        // Constrain threshold to [0, 85]
+        var minElevation = ((rawThreshold % 86) + 86) % 86;
+
+        var result = WeightedIntervalScheduler.Solve(
+            candidates,
+            minimumElevationDeg: minElevation);
+
+        return result.All(sp => sp.Scored.Pass.MaxElevationDeg >= minElevation);
+    }
+
+    // ─── Property 6: Tie-Breaking by Elevation ───────────────────────────────────
+    // Feature: session-planner, Property 6: Tie-Breaking by Elevation
+    // **Validates: Requirements 4.5**
+
+    /// <summary>
+    /// For any pair of overlapping candidate passes with identical composite scores,
+    /// if one has a strictly higher MaxElevationDeg, then the scheduler output SHALL
+    /// contain the higher-elevation pass (not the lower).
+    /// </summary>
+    [Property]
+    public bool TieBreakingByElevation(int rawStart, int rawDuration, int rawOffset, int rawElevLow, int rawElevHigh, int rawPriority)
+    {
+        // Constrain parameters
+        var startMinutes = ((rawStart % 1400) + 1400) % 1400;
+        var durationMinutes = 3 + (((rawDuration % 10) + 10) % 10); // 3..12
+        var overlapOffset = 1 + (((rawOffset % (durationMinutes - 1)) + (durationMinutes - 1)) % (durationMinutes - 1)); // 1..durationMinutes-1
+        var elevLow = 10 + (((rawElevLow % 35) + 35) % 35);   // 10..44
+        var elevHigh = 45 + (((rawElevHigh % 45) + 45) % 45); // 45..89
+        var priority = 1 + (((rawPriority % 10) + 10) % 10);  // 1..10
+
+        var baseTime = new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var aos1 = baseTime.AddMinutes(startMinutes);
+        var los1 = aos1.AddMinutes(durationMinutes);
+        var aos2 = aos1.AddMinutes(overlapOffset); // overlaps with pass 1
+        var los2 = aos2.AddMinutes(durationMinutes);
+
+        // Use identical composite scores for both passes
+        const double compositeScore = 5.0;
+
+        var passLow = new ScoredPass
+        {
+            Pass = new PassInfo
+            {
+                SatelliteName = "SAT-LOW",
+                NoradId = "25544",
+                AosUtc = aos1,
+                LosUtc = los1,
+                MaxElevationDeg = elevLow,
+                MaxElevationUtc = aos1.AddMinutes(durationMinutes / 2.0)
+            },
+            QualityScore = 0.5,
+            SatellitePriority = priority,
+            CompositeScore = compositeScore
+        };
+
+        var passHigh = new ScoredPass
+        {
+            Pass = new PassInfo
+            {
+                SatelliteName = "SAT-HIGH",
+                NoradId = "25545",
+                AosUtc = aos2,
+                LosUtc = los2,
+                MaxElevationDeg = elevHigh,
+                MaxElevationUtc = aos2.AddMinutes(durationMinutes / 2.0)
+            },
+            QualityScore = 0.5,
+            SatellitePriority = priority,
+            CompositeScore = compositeScore
+        };
+
+        var candidates = new List<ScoredPass> { passLow, passHigh };
+        var result = WeightedIntervalScheduler.Solve(candidates);
+
+        // The solver should pick the higher-elevation pass due to tie-breaking
+        if (result.Count != 1)
+            return false;
+
+        return result[0].Scored.Pass.MaxElevationDeg == elevHigh;
+    }
+
+    // ─── Property 7: Output Sorted by AOS ────────────────────────────────────────
+    // Feature: session-planner, Property 7: Output Sorted by AOS
+    // **Validates: Requirements 5.1**
+
+    /// <summary>
+    /// For any valid scheduler output, the list of selected passes SHALL be in
+    /// strictly ascending order of AosUtc.
+    /// </summary>
+    [Property]
+    public bool OutputSortedByAos(int[] seeds)
+    {
+        if (seeds == null || seeds.Length == 0)
+            return true;
+
+        var limited = seeds.Take(20).ToArray();
+        var candidates = BuildCandidates(limited);
+
+        var result = WeightedIntervalScheduler.Solve(candidates);
+
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            if (result[i].Scored.Pass.AosUtc >= result[i + 1].Scored.Pass.AosUtc)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/OscarWatch/App.axaml.cs
+++ b/OscarWatch/App.axaml.cs
@@ -100,6 +100,10 @@ public partial class App : Application
         services.AddTransient<QsoLogbookViewModel>();
         services.AddTransient<CreateLogbookViewModel>();
         services.AddTransient<LogbookSettingsViewModel>();
+        services.AddSingleton<OscarWatch.Core.SessionPlanner.SessionPlannerService>();
+        services.AddSingleton<OscarWatch.Core.SessionPlanner.PlanExecutor>(sp =>
+            new OscarWatch.Core.SessionPlanner.PlanExecutor(sp.GetRequiredService<ILiveTrackingService>()));
+        services.AddTransient<SessionPlannerViewModel>();
 
         Services = services.BuildServiceProvider();
 

--- a/OscarWatch/MainWindow.axaml
+++ b/OscarWatch/MainWindow.axaml
@@ -37,6 +37,7 @@
       </MenuItem>
       <MenuItem Header="{loc:Localize Key=Menu.Passes}">
         <MenuItem Header="{loc:Localize Key=Menu.Passes.Planner}" Command="{Binding OpenPassPlanningCommand}" />
+        <MenuItem Header="{loc:Localize Key=Menu.Passes.SessionPlanner}" Command="{Binding OpenSessionPlannerCommand}" />
         <MenuItem Header="{loc:Localize Key=Menu.Passes.Mutual}" Command="{Binding OpenMutualPassFinderCommand}" />
         <Separator />
         <MenuItem Header="{loc:Localize Key=Menu.Passes.Sunlight}" Command="{Binding OpenSunlightPredictionCommand}" />

--- a/OscarWatch/Resources/Strings.resx
+++ b/OscarWatch/Resources/Strings.resx
@@ -459,6 +459,9 @@ Continue?</value>
   <data name="Menu.Passes.Planner">
     <value>_Pass Planner</value>
   </data>
+  <data name="Menu.Passes.SessionPlanner">
+    <value>_Session Planner</value>
+  </data>
   <data name="Menu.Passes.Sunlight">
     <value>_Sunlight Prediction</value>
   </data>

--- a/OscarWatch/ViewModels/MainViewModel.cs
+++ b/OscarWatch/ViewModels/MainViewModel.cs
@@ -1824,6 +1824,18 @@ public partial class MainViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private async Task OpenSessionPlannerAsync()
+    {
+        var vm = App.Services.GetRequiredService<SessionPlannerViewModel>();
+        vm.Initialize();
+        var window = new SessionPlannerWindow { DataContext = vm };
+        if (App.MainWindow is null)
+            return;
+
+        await window.ShowDialog(App.MainWindow);
+    }
+
+    [RelayCommand]
     private void ToggleSoloFocusedSatellite()
     {
         if (!SoloFocusedSatellite)

--- a/OscarWatch/ViewModels/SessionPlannerViewModel.cs
+++ b/OscarWatch/ViewModels/SessionPlannerViewModel.cs
@@ -1,0 +1,519 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OscarWatch.Core.Export;
+using OscarWatch.Core.Models;
+using OscarWatch.Core.Services;
+using OscarWatch.Core.SessionPlanner;
+using OscarWatch.Localization;
+
+namespace OscarWatch.ViewModels;
+
+public partial class SessionPlannerViewModel : ViewModelBase
+{
+    private readonly SessionPlannerService _plannerService;
+    private readonly PlanExecutor _executor;
+    private readonly ISettingsService _settings;
+    private readonly ILocalizationService _localization;
+
+    public ObservableCollection<SessionPlanPassRow> ScheduledPasses { get; } = [];
+
+    [ObservableProperty]
+    private DateTime _sessionStartTime;
+
+    [ObservableProperty]
+    private DateTime _sessionEndTime;
+
+    /// <summary>Date portion of session start for CalendarDatePicker binding.</summary>
+    public DateTime? SessionStartDate
+    {
+        get => SessionStartTime.Date;
+        set
+        {
+            if (value is not null)
+            {
+                SessionStartTime = value.Value.Date + SessionStartTime.TimeOfDay;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>Time-of-day portion of session start for TimePicker binding.</summary>
+    public TimeSpan? SessionStartTimeOfDay
+    {
+        get => SessionStartTime.TimeOfDay;
+        set
+        {
+            if (value is not null)
+            {
+                SessionStartTime = SessionStartTime.Date + value.Value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>Date portion of session end for CalendarDatePicker binding.</summary>
+    public DateTime? SessionEndDate
+    {
+        get => SessionEndTime.Date;
+        set
+        {
+            if (value is not null)
+            {
+                SessionEndTime = value.Value.Date + SessionEndTime.TimeOfDay;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>Time-of-day portion of session end for TimePicker binding.</summary>
+    public TimeSpan? SessionEndTimeOfDay
+    {
+        get => SessionEndTime.TimeOfDay;
+        set
+        {
+            if (value is not null)
+            {
+                SessionEndTime = SessionEndTime.Date + value.Value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    partial void OnSessionStartTimeChanged(DateTime value)
+    {
+        OnPropertyChanged(nameof(SessionStartDate));
+        OnPropertyChanged(nameof(SessionStartTimeOfDay));
+    }
+
+    partial void OnSessionEndTimeChanged(DateTime value)
+    {
+        OnPropertyChanged(nameof(SessionEndDate));
+        OnPropertyChanged(nameof(SessionEndTimeOfDay));
+    }
+
+    [ObservableProperty]
+    private SessionPlan? _activePlan;
+
+    [ObservableProperty]
+    private PlanExecutionState _executionState;
+
+    [ObservableProperty]
+    private string _currentPassDisplay = "";
+
+    [ObservableProperty]
+    private string _nextPassDisplay = "";
+
+    [ObservableProperty]
+    private string _countdownText = "";
+
+    [ObservableProperty]
+    private string _progressText = "";
+
+    [ObservableProperty]
+    private string _statusText = "";
+
+    [ObservableProperty]
+    private bool _isReviewOnly;
+
+    [ObservableProperty]
+    private bool _useUtcTime;
+
+    [ObservableProperty]
+    private bool _use24HourClock;
+
+    public SessionPlannerViewModel(
+        SessionPlannerService plannerService,
+        PlanExecutor executor,
+        ISettingsService settings,
+        ILocalizationService localization)
+    {
+        _plannerService = plannerService;
+        _executor = executor;
+        _settings = settings;
+        _localization = localization;
+    }
+
+    /// <summary>
+    /// Initialises default values from settings. Call after construction.
+    /// </summary>
+    public void Initialize()
+    {
+        var current = _settings.Current;
+        UseUtcTime = current.PassPlannerUseUtcTime;
+        Use24HourClock = current.Use24HourClock;
+
+        var now = UseUtcTime ? DateTime.UtcNow : DateTime.Now;
+        SessionStartTime = SessionPlannerService.RoundUpTo15Minutes(now);
+        SessionEndTime = SessionStartTime.AddHours(current.PassPredictionHours);
+
+        ExecutionState = PlanExecutionState.Idle;
+        StatusText = "";
+    }
+
+    [RelayCommand]
+    private async Task GeneratePlanAsync(CancellationToken cancellationToken)
+    {
+        // Validate time window
+        if (SessionEndTime <= SessionStartTime)
+        {
+            StatusText = _localization.Get("SessionPlanner.Error.EndBeforeStart");
+            return;
+        }
+
+        if (SessionEndTime - SessionStartTime > TimeSpan.FromHours(48))
+        {
+            StatusText = _localization.Get("SessionPlanner.Error.MaxDurationExceeded");
+            return;
+        }
+
+        StatusText = _localization.Get("SessionPlanner.Status.Generating");
+
+        try
+        {
+            var startUtc = UseUtcTime ? SessionStartTime : SessionStartTime.ToUniversalTime();
+            var endUtc = UseUtcTime ? SessionEndTime : SessionEndTime.ToUniversalTime();
+
+            var plan = await _plannerService.GeneratePlanAsync(startUtc, endUtc, cancellationToken);
+            ActivePlan = plan;
+            IsReviewOnly = endUtc <= DateTime.UtcNow;
+
+            RebuildScheduledPasses();
+
+            StatusText = plan.ScheduledCount > 0
+                ? _localization.Get("SessionPlanner.Status.Generated", plan.ScheduledCount)
+                : _localization.Get("SessionPlanner.Status.NoPasses");
+        }
+        catch (ArgumentException ex)
+        {
+            StatusText = ex.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void StartExecution()
+    {
+        if (ActivePlan is null || IsReviewOnly)
+            return;
+
+        var preAlertMinutes = _settings.Current.SessionPlannerPreAlertMinutes;
+        _executor.Start(ActivePlan, preAlertMinutes);
+        ExecutionState = _executor.State;
+        UpdateDisplayProperties();
+    }
+
+    [RelayCommand]
+    private void StopExecution()
+    {
+        _executor.Stop();
+        ExecutionState = _executor.State;
+        CurrentPassDisplay = "";
+        NextPassDisplay = "";
+        CountdownText = "";
+        ProgressText = "";
+    }
+
+    [RelayCommand]
+    private void PauseExecution()
+    {
+        _executor.Pause();
+        ExecutionState = _executor.State;
+    }
+
+    [RelayCommand]
+    private void ResumeExecution()
+    {
+        _executor.Resume();
+        ExecutionState = _executor.State;
+    }
+
+    [RelayCommand]
+    private void ExcludePass(SessionPlanPassRow? row)
+    {
+        if (row is null || ActivePlan is null)
+            return;
+
+        var excludedIds = ActivePlan.ExcludedIds.ToHashSet();
+        excludedIds.Add(row.Source.Scored.Id);
+
+        var adjusted = _plannerService.AdjustPlan(
+            ActivePlan,
+            excludedIds: excludedIds,
+            forcedInclusionIds: ActivePlan.ForcedInclusionIds);
+
+        ActivePlan = adjusted;
+        RebuildScheduledPasses();
+    }
+
+    [RelayCommand]
+    private void ForceIncludePass(SessionPlanPassRow? row)
+    {
+        if (row is null || ActivePlan is null)
+            return;
+
+        var forcedIds = ActivePlan.ForcedInclusionIds.ToHashSet();
+        forcedIds.Add(row.Source.Scored.Id);
+
+        var adjusted = _plannerService.AdjustPlan(
+            ActivePlan,
+            excludedIds: ActivePlan.ExcludedIds,
+            forcedInclusionIds: forcedIds);
+
+        ActivePlan = adjusted;
+        RebuildScheduledPasses();
+    }
+
+    [RelayCommand]
+    private async Task ResetAdjustments(CancellationToken cancellationToken)
+    {
+        if (ActivePlan is null)
+            return;
+
+        StatusText = _localization.Get("SessionPlanner.Status.Generating");
+
+        var startUtc = ActivePlan.SessionStartUtc;
+        var endUtc = ActivePlan.SessionEndUtc;
+
+        var plan = await _plannerService.GeneratePlanAsync(startUtc, endUtc, cancellationToken);
+        ActivePlan = plan;
+        RebuildScheduledPasses();
+
+        StatusText = _localization.Get("SessionPlanner.Status.Generated", plan.ScheduledCount);
+    }
+
+    /// <summary>
+    /// Builds the CSV export string for the active plan.
+    /// The view is responsible for presenting a file-save dialogue.
+    /// </summary>
+    [RelayCommand]
+    private void ExportCsv()
+    {
+        if (ActivePlan is null)
+            return;
+
+        LastExportContent = SessionPlanExporter.BuildCsv(ActivePlan);
+    }
+
+    /// <summary>
+    /// Builds the ICS export string for the active plan.
+    /// The view is responsible for presenting a file-save dialogue.
+    /// </summary>
+    [RelayCommand]
+    private void ExportIcs()
+    {
+        if (ActivePlan is null)
+            return;
+
+        var station = _settings.Current.GroundStation;
+        var preAlertMinutes = _settings.Current.SessionPlannerPreAlertMinutes;
+        LastExportContent = SessionPlanExporter.BuildCalendar(ActivePlan, station, preAlertMinutes);
+    }
+
+    /// <summary>
+    /// Serialises the active plan to JSON. The view is responsible for writing to file.
+    /// </summary>
+    [RelayCommand]
+    private void SavePlan()
+    {
+        if (ActivePlan is null)
+            return;
+
+        LastExportContent = SessionPlanPersistence.Serialise(ActivePlan);
+    }
+
+    /// <summary>
+    /// Contains the last export/save result string for the view to consume.
+    /// </summary>
+    public string LastExportContent { get; private set; } = "";
+
+    [RelayCommand]
+    private void LoadPlan(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            StatusText = _localization.Get("SessionPlanner.Error.EmptyFile");
+            return;
+        }
+
+        var plan = SessionPlanPersistence.Deserialise(json);
+        if (plan is null)
+        {
+            StatusText = _localization.Get("SessionPlanner.Error.MalformedFile");
+            return;
+        }
+
+        ActivePlan = plan;
+        SessionStartTime = UseUtcTime ? plan.SessionStartUtc : plan.SessionStartUtc.ToLocalTime();
+        SessionEndTime = UseUtcTime ? plan.SessionEndUtc : plan.SessionEndUtc.ToLocalTime();
+        IsReviewOnly = plan.SessionEndUtc <= DateTime.UtcNow;
+
+        RebuildScheduledPasses();
+        StatusText = _localization.Get("SessionPlanner.Status.Loaded", plan.ScheduledCount);
+    }
+
+    /// <summary>
+    /// Called by a DispatcherTimer (typically 1-second interval) from outside.
+    /// Drives the executor and updates display properties.
+    /// </summary>
+    public void Tick()
+    {
+        if (_executor.State == PlanExecutionState.Idle || _executor.State == PlanExecutionState.Completed)
+            return;
+
+        _executor.Tick(DateTime.UtcNow);
+        ExecutionState = _executor.State;
+        UpdateDisplayProperties();
+    }
+
+    private void UpdateDisplayProperties()
+    {
+        var currentPass = _executor.CurrentPass;
+        var nextPass = _executor.NextPass;
+        var timeToNext = _executor.TimeToNextSwitch;
+
+        // Current pass display
+        if (currentPass is not null)
+        {
+            var elev = currentPass.Scored.Pass.MaxElevationDeg;
+            CurrentPassDisplay = $"{currentPass.Scored.Pass.SatelliteName} ({elev:F0}°)";
+        }
+        else
+        {
+            CurrentPassDisplay = _localization.Get("SessionPlanner.Display.Gap");
+        }
+
+        // Next pass display
+        if (nextPass is not null && timeToNext is not null)
+        {
+            var remaining = timeToNext.Value;
+            var formatted = remaining.TotalHours >= 1
+                ? $"{(int)remaining.TotalHours}:{remaining.Minutes:D2}:{remaining.Seconds:D2}"
+                : $"{remaining.Minutes}:{remaining.Seconds:D2}";
+            NextPassDisplay = $"{nextPass.Scored.Pass.SatelliteName} in {formatted}";
+        }
+        else
+        {
+            NextPassDisplay = "";
+        }
+
+        // Countdown text
+        if (timeToNext is not null)
+        {
+            var remaining = timeToNext.Value;
+            CountdownText = remaining.TotalHours >= 1
+                ? $"{(int)remaining.TotalHours}:{remaining.Minutes:D2}:{remaining.Seconds:D2}"
+                : $"{remaining.Minutes}:{remaining.Seconds:D2}";
+        }
+        else
+        {
+            CountdownText = "";
+        }
+
+        // Progress text
+        if (ActivePlan is not null && ActivePlan.ScheduledCount > 0)
+        {
+            var total = ActivePlan.ScheduledCount;
+            var completed = CountCompletedPasses();
+            var currentIndex = completed + 1;
+            if (currentIndex > total) currentIndex = total;
+
+            var sessionDuration = (ActivePlan.SessionEndUtc - ActivePlan.SessionStartUtc).TotalSeconds;
+            var elapsed = (DateTime.UtcNow - ActivePlan.SessionStartUtc).TotalSeconds;
+            var percent = sessionDuration > 0
+                ? (int)Math.Clamp(elapsed / sessionDuration * 100, 0, 100)
+                : 0;
+
+            ProgressText = $"Pass {currentIndex} of {total} ({percent}%)";
+        }
+        else
+        {
+            ProgressText = "";
+        }
+    }
+
+    private int CountCompletedPasses()
+    {
+        if (ActivePlan is null) return 0;
+
+        var now = DateTime.UtcNow;
+        var count = 0;
+        foreach (var pass in ActivePlan.ScheduledPasses)
+        {
+            if (now > pass.Scored.Pass.LosUtc)
+                count++;
+        }
+        return count;
+    }
+
+    private void RebuildScheduledPasses()
+    {
+        ScheduledPasses.Clear();
+
+        if (ActivePlan is null)
+            return;
+
+        var passes = ActivePlan.ScheduledPasses;
+        for (var i = 0; i < passes.Count; i++)
+        {
+            var scheduled = passes[i];
+            var pass = scheduled.Scored.Pass;
+
+            var gapBefore = "";
+            var isTightGap = false;
+            if (i > 0)
+            {
+                var previousLos = passes[i - 1].Scored.Pass.LosUtc;
+                var gap = pass.AosUtc - previousLos;
+                gapBefore = FormatDuration(gap);
+                isTightGap = gap < TimeSpan.FromMinutes(2);
+            }
+
+            ScheduledPasses.Add(new SessionPlanPassRow
+            {
+                Source = scheduled,
+                SatelliteName = pass.SatelliteName,
+                AosDisplay = FormatTime(pass.AosUtc),
+                LosDisplay = FormatTime(pass.LosUtc),
+                MaxElevation = $"{pass.MaxElevationDeg:F1}°",
+                CompositeScore = $"{scheduled.Scored.CompositeScore:F1}",
+                Duration = FormatDuration(pass.Duration),
+                GapBefore = gapBefore,
+                IsTightGap = isTightGap,
+                IsForceIncluded = scheduled.Reason == PassSelectionReason.ForceIncluded,
+                Reason = scheduled.Reason.ToString()
+            });
+        }
+    }
+
+    private string FormatTime(DateTime utcTime)
+    {
+        var displayTime = UseUtcTime ? utcTime : utcTime.ToLocalTime();
+        var format = Use24HourClock ? "HH:mm:ss" : "h:mm:ss tt";
+        return displayTime.ToString(format);
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalHours >= 1)
+            return $"{(int)duration.TotalHours}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+        return $"{duration.Minutes}:{duration.Seconds:D2}";
+    }
+}
+
+/// <summary>
+/// Display row for the session planner timeline.
+/// </summary>
+public sealed class SessionPlanPassRow
+{
+    public required ScheduledPass Source { get; init; }
+    public string SatelliteName { get; init; } = "";
+    public string AosDisplay { get; init; } = "";
+    public string LosDisplay { get; init; } = "";
+    public string MaxElevation { get; init; } = "";
+    public string CompositeScore { get; init; } = "";
+    public string Duration { get; init; } = "";
+    public string GapBefore { get; init; } = "";
+    public bool IsTightGap { get; init; }
+    public bool IsForceIncluded { get; init; }
+    public string Reason { get; init; } = "";
+}

--- a/OscarWatch/Views/SessionPlannerWindow.axaml
+++ b/OscarWatch/Views/SessionPlannerWindow.axaml
@@ -1,0 +1,154 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:OscarWatch.ViewModels"
+        xmlns:loc="using:OscarWatch.Localization"
+        x:Class="OscarWatch.Views.SessionPlannerWindow"
+        x:DataType="vm:SessionPlannerViewModel"
+        Title="Session Planner"
+        Width="1100" Height="620"
+        MinWidth="900" MinHeight="480"
+        WindowStartupLocation="CenterOwner">
+  <DockPanel Margin="12">
+
+    <!-- Status bar and close button -->
+    <Border DockPanel.Dock="Bottom"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="0,1,0,0"
+            Padding="0,10,0,0"
+            Margin="0,10,0,0">
+      <Grid ColumnDefinitions="*,Auto">
+        <TextBlock Grid.Column="0"
+                   Text="{Binding StatusText}"
+                   VerticalAlignment="Center"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+          <Button Content="Close" Click="OnCloseClick" MinWidth="80" />
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto">
+
+      <!-- Row 0: Session time window -->
+      <Border Grid.Row="0"
+              Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+              CornerRadius="4"
+              Padding="12,8"
+              Margin="0,0,0,8">
+        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+              ColumnSpacing="8">
+          <TextBlock Grid.Column="0" Text="Start:" VerticalAlignment="Center" FontWeight="SemiBold" />
+          <CalendarDatePicker Grid.Column="1" SelectedDate="{Binding SessionStartDate}" MinWidth="130" />
+          <TimePicker Grid.Column="2" SelectedTime="{Binding SessionStartTimeOfDay}" MinuteIncrement="5" MinWidth="100" ClockIdentifier="24HourClock" />
+          <TextBlock Grid.Column="3" Text="End:" VerticalAlignment="Center" FontWeight="SemiBold" />
+          <CalendarDatePicker Grid.Column="4" SelectedDate="{Binding SessionEndDate}" MinWidth="130" />
+          <TimePicker Grid.Column="5" SelectedTime="{Binding SessionEndTimeOfDay}" MinuteIncrement="5" MinWidth="100" ClockIdentifier="24HourClock" />
+          <Button Grid.Column="6"
+                  Content="Generate Plan"
+                  Command="{Binding GeneratePlanCommand}"
+                  Classes="accent"
+                  MinWidth="120" />
+          <Button Grid.Column="7"
+                  Content="Reset"
+                  Command="{Binding ResetAdjustmentsCommand}"
+                  MinWidth="70" />
+        </Grid>
+      </Border>
+
+      <!-- Row 1: Execution controls and progress -->
+      <Border Grid.Row="1"
+              Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+              CornerRadius="4"
+              Padding="12,8"
+              Margin="0,0,0,8">
+        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto">
+          <Button Grid.Column="0" Content="▶ Start" Command="{Binding StartExecutionCommand}" MinWidth="70"
+                  IsEnabled="{Binding ActivePlan, Converter={x:Static ObjectConverters.IsNotNull}}" />
+          <Button Grid.Column="1" Content="⏸ Pause" Command="{Binding PauseExecutionCommand}" MinWidth="70" Margin="4,0" />
+          <Button Grid.Column="2" Content="▶ Resume" Command="{Binding ResumeExecutionCommand}" MinWidth="70" />
+          <Button Grid.Column="3" Content="⏹ Stop" Command="{Binding StopExecutionCommand}" MinWidth="70" Margin="4,0" />
+          <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center" Margin="12,0,0,0">
+            <TextBlock Text="{Binding CurrentPassDisplay}" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding NextPassDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+          </StackPanel>
+          <TextBlock Grid.Column="5" Text="{Binding CountdownText}" FontFamily="Consolas,Courier New,monospace" VerticalAlignment="Center" />
+          <TextBlock Grid.Column="6" Text="{Binding ProgressText}" VerticalAlignment="Center" Margin="12,0,0,0"
+                     Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        </Grid>
+      </Border>
+
+      <!-- Row 2: Timeline / schedule list -->
+      <DataGrid Grid.Row="2"
+                x:Name="ScheduleDataGrid"
+                ItemsSource="{Binding ScheduledPasses}"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                CanUserResizeColumns="False"
+                CanUserReorderColumns="False"
+                CanUserSortColumns="False"
+                GridLinesVisibility="Horizontal"
+                HeadersVisibility="Column"
+                MinHeight="120"
+                BorderThickness="0">
+        <DataGrid.ContextMenu>
+          <ContextMenu>
+            <MenuItem Header="Exclude Pass"
+                      Command="{Binding ExcludePassCommand}"
+                      CommandParameter="{Binding #ScheduleDataGrid.SelectedItem}" />
+            <MenuItem Header="Force Include Pass"
+                      Command="{Binding ForceIncludePassCommand}"
+                      CommandParameter="{Binding #ScheduleDataGrid.SelectedItem}" />
+          </ContextMenu>
+        </DataGrid.ContextMenu>
+        <DataGrid.Styles>
+          <Style Selector="DataGridColumnHeader">
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Padding" Value="4,6" />
+          </Style>
+          <Style Selector="DataGridCell">
+            <Setter Property="Padding" Value="4,3" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+          </Style>
+        </DataGrid.Styles>
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Satellite"
+                              Binding="{Binding SatelliteName, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto" />
+          <DataGridTextColumn Header="AOS"
+                              Binding="{Binding AosDisplay, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+          <DataGridTextColumn Header="LOS"
+                              Binding="{Binding LosDisplay, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+          <DataGridTextColumn Header="Elev"
+                              Binding="{Binding MaxElevation, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+          <DataGridTextColumn Header="Score"
+                              Binding="{Binding CompositeScore, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+          <DataGridTextColumn Header="Duration"
+                              Binding="{Binding Duration, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+          <DataGridTextColumn Header="Gap"
+                              Binding="{Binding GapBefore, DataType={x:Type vm:SessionPlanPassRow}}"
+                              Width="Auto"
+                              FontFamily="Consolas,Courier New,monospace" />
+        </DataGrid.Columns>
+      </DataGrid>
+
+      <!-- Row 3: Export buttons -->
+      <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+        <Button Content="Export CSV" Command="{Binding ExportCsvCommand}" Click="OnExportCsvClick" MinWidth="90" />
+        <Button Content="Export ICS" Command="{Binding ExportIcsCommand}" Click="OnExportIcsClick" MinWidth="90" />
+        <Button Content="Save Plan" Command="{Binding SavePlanCommand}" Click="OnSavePlanClick" MinWidth="90" />
+        <Button Content="Load Plan" Click="OnLoadPlanClick" MinWidth="90" />
+      </StackPanel>
+    </Grid>
+  </DockPanel>
+</Window>

--- a/OscarWatch/Views/SessionPlannerWindow.axaml.cs
+++ b/OscarWatch/Views/SessionPlannerWindow.axaml.cs
@@ -1,0 +1,109 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using OscarWatch.ViewModels;
+
+namespace OscarWatch.Views;
+
+public partial class SessionPlannerWindow : Window
+{
+    public SessionPlannerWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
+
+    private async void OnExportCsvClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SessionPlannerViewModel vm || string.IsNullOrEmpty(vm.LastExportContent))
+            return;
+
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var file = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Export Session Plan as CSV",
+            SuggestedFileName = "session-plan.csv",
+            DefaultExtension = "csv",
+            FileTypeChoices = [new FilePickerFileType("CSV") { Patterns = ["*.csv"] }]
+        });
+
+        if (file is null) return;
+
+        await using var stream = await file.OpenWriteAsync();
+        await using var writer = new System.IO.StreamWriter(stream);
+        await writer.WriteAsync(vm.LastExportContent);
+    }
+
+    private async void OnExportIcsClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SessionPlannerViewModel vm || string.IsNullOrEmpty(vm.LastExportContent))
+            return;
+
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var file = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Export Session Plan as ICS",
+            SuggestedFileName = "session-plan.ics",
+            DefaultExtension = "ics",
+            FileTypeChoices = [new FilePickerFileType("ICS Calendar") { Patterns = ["*.ics"] }]
+        });
+
+        if (file is null) return;
+
+        await using var stream = await file.OpenWriteAsync();
+        await using var writer = new System.IO.StreamWriter(stream);
+        await writer.WriteAsync(vm.LastExportContent);
+    }
+
+    private async void OnSavePlanClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SessionPlannerViewModel vm || string.IsNullOrEmpty(vm.LastExportContent))
+            return;
+
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var file = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save Session Plan",
+            SuggestedFileName = "session-plan.json",
+            DefaultExtension = "json",
+            FileTypeChoices = [new FilePickerFileType("JSON") { Patterns = ["*.json"] }]
+        });
+
+        if (file is null) return;
+
+        await using var stream = await file.OpenWriteAsync();
+        await using var writer = new System.IO.StreamWriter(stream);
+        await writer.WriteAsync(vm.LastExportContent);
+    }
+
+    private async void OnLoadPlanClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SessionPlannerViewModel vm)
+            return;
+
+        var storage = GetTopLevel(this)?.StorageProvider;
+        if (storage is null) return;
+
+        var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Load Session Plan",
+            AllowMultiple = false,
+            FileTypeFilter = [new FilePickerFileType("JSON") { Patterns = ["*.json"] }]
+        });
+
+        if (files.Count == 0) return;
+
+        await using var stream = await files[0].OpenReadAsync();
+        using var reader = new System.IO.StreamReader(stream);
+        var json = await reader.ReadToEndAsync();
+
+        vm.LoadPlanCommand.Execute(json);
+    }
+}

--- a/docs/building-macos-dmg.md
+++ b/docs/building-macos-dmg.md
@@ -1,0 +1,158 @@
+# Building a macOS DMG
+
+Instructions for creating a distributable `.dmg` disk image for OscarWatch on macOS.
+
+## Prerequisites
+
+- .NET 10 SDK installed (`dotnet --version` should show 10.x)
+- macOS with `hdiutil` (included with every macOS installation)
+- For Apple Silicon: build on an ARM64 Mac (or cross-compile with `-r osx-arm64`)
+- For Intel: use `-r osx-x64`
+
+## Quick build (one-liner)
+
+```bash
+# Apple Silicon
+./build-dmg.sh osx-arm64
+
+# Intel
+./build-dmg.sh osx-x64
+```
+
+If the script doesn't exist yet, follow the manual steps below.
+
+## Manual steps
+
+### 1. Publish the application
+
+```bash
+# Clean previous output
+rm -rf publish/osx-arm64 publish/OscarWatch.app
+
+# Publish self-contained for macOS ARM64
+dotnet publish OscarWatch/OscarWatch.csproj \
+  -c Release \
+  -r osx-arm64 \
+  --self-contained true \
+  -o publish/osx-arm64
+```
+
+For Intel Macs, replace `osx-arm64` with `osx-x64` throughout.
+
+### 2. Create the .app bundle structure
+
+```bash
+mkdir -p publish/OscarWatch.app/Contents/MacOS
+mkdir -p publish/OscarWatch.app/Contents/Resources
+```
+
+### 3. Create Info.plist
+
+```bash
+cat > publish/OscarWatch.app/Contents/Info.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>OscarWatch</string>
+    <key>CFBundleDisplayName</key>
+    <string>OscarWatch</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.oscarwatch.tracker</string>
+    <key>CFBundleVersion</key>
+    <string>0.9.6</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.9.6</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>OscarWatch</string>
+    <key>CFBundleIconFile</key>
+    <string>OscarWatch.icns</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>OscarWatch uses the microphone for pass audio recording.</string>
+</dict>
+</plist>
+EOF
+```
+
+Update `CFBundleVersion` and `CFBundleShortVersionString` to match the release version.
+
+### 4. Copy published files into the bundle
+
+```bash
+cp -R publish/osx-arm64/* publish/OscarWatch.app/Contents/MacOS/
+chmod +x publish/OscarWatch.app/Contents/MacOS/OscarWatch
+```
+
+### 5. (Optional) Add an app icon
+
+If you have an `.icns` file:
+
+```bash
+cp path/to/OscarWatch.icns publish/OscarWatch.app/Contents/Resources/
+```
+
+### 6. (Optional) Code sign
+
+For distribution outside the App Store, ad-hoc signing removes the "damaged" warning for some users:
+
+```bash
+codesign --force --deep --sign - publish/OscarWatch.app
+```
+
+For proper distribution, sign with a Developer ID certificate:
+
+```bash
+codesign --force --deep --sign "Developer ID Application: Your Name (TEAMID)" \
+  --options runtime \
+  publish/OscarWatch.app
+```
+
+### 7. Create the DMG
+
+```bash
+hdiutil create \
+  -volname "OscarWatch" \
+  -srcfolder publish/OscarWatch.app \
+  -ov \
+  -format UDZO \
+  publish/OscarWatch-0.9.6-osx-arm64.dmg
+```
+
+The `-format UDZO` flag compresses the image (typically ~66 MB for OscarWatch).
+
+### 8. (Optional) Notarise
+
+Required for users to open the app without Gatekeeper warnings on macOS 10.15+:
+
+```bash
+xcrun notarytool submit publish/OscarWatch-0.9.6-osx-arm64.dmg \
+  --apple-id "your@email.com" \
+  --team-id "TEAMID" \
+  --password "@keychain:AC_PASSWORD" \
+  --wait
+
+# After notarisation succeeds, staple the ticket
+xcrun stapler staple publish/OscarWatch-0.9.6-osx-arm64.dmg
+```
+
+## Output
+
+The final DMG will be at:
+
+```
+publish/OscarWatch-{version}-{rid}.dmg
+```
+
+## Notes
+
+- The app is **not code-signed or notarised** by default. Users will see a Gatekeeper warning on first launch. They can bypass it with right-click → Open, or System Settings → Privacy & Security → Open Anyway.
+- The `.app` bundle includes the full .NET runtime (~66 MB compressed) since it's self-contained.
+- The `publish/` directory is in `.gitignore` and should not be committed.
+- For CI/CD, the GitHub Actions workflow in `.github/workflows/publish.yml` produces `tar.gz` archives for macOS. The DMG creation is a local-only step for now.

--- a/docs/session-planner-pr-summary.md
+++ b/docs/session-planner-pr-summary.md
@@ -1,0 +1,136 @@
+# Session Planner — Feature Summary
+
+## What it does
+
+The Session Planner lets operators define a time window for an operating session and automatically generates an optimal schedule of satellite passes to work. It uses weighted interval scheduling to select a non-overlapping subset of passes that maximises a combined score of pass quality and satellite priority. During plan execution, the application automatically switches the focused satellite at each pass's AOS time and provides pre-alert notifications.
+
+## How to access it
+
+**Passes → Session Planner** in the menu bar. Opens as a modal window.
+
+## UI Layout
+
+- **Top bar**: CalendarDatePicker + TimePicker for start and end times, Generate Plan button, Reset button
+- **Execution controls**: Start, Pause, Resume, Stop buttons with live current-pass display, countdown, and progress
+- **Schedule table**: Satellite, AOS, LOS, Elevation, Score, Duration, Gap columns (auto-sized)
+- **Bottom bar**: Export CSV, Export ICS, Save Plan, Load Plan buttons; Close button
+
+## New files added
+
+### OscarWatch.Core/SessionPlanner/
+| File | Purpose |
+|------|---------|
+| `TransponderCategory.cs` | Enum: Linear, Fm, Mixed, Unknown |
+| `ScoredPass.cs` | Candidate pass with quality/composite scores |
+| `ScheduledPass.cs` | Selected pass + selection reason enum |
+| `SessionPlan.cs` | Immutable plan with scheduled passes, candidates, exclusions |
+| `PlanExecutionState.cs` | Enum: Idle, Running, Paused, Completed |
+| `PlanExecutorAction.cs` | Discriminated union for tick results (NoAction, SwitchFocus, RaisePreAlert, MarkCompleted) |
+| `PassQualityScorer.cs` | Pure static scoring: elevation×0.5 + duration×0.3 + transponder×0.2, composite formula |
+| `WeightedIntervalScheduler.cs` | O(n log n) DP algorithm for optimal non-overlapping pass selection |
+| `SessionPlannerService.cs` | Orchestration: predict → score → schedule, with validation and adjustment |
+| `PlanExecutor.cs` | Timer-driven state machine for focus switching and pre-alerts |
+| `SessionPlanPersistence.cs` | JSON serialise/deserialise with version validation |
+
+### OscarWatch.Core/Export/
+| File | Purpose |
+|------|---------|
+| `SessionPlanExporter.cs` | CSV and ICS (with VALARM pre-alerts) export |
+
+### OscarWatch/ViewModels/
+| File | Purpose |
+|------|---------|
+| `SessionPlannerViewModel.cs` | Full MVVM ViewModel with all commands, date/time picker bindings, execution tick |
+
+### OscarWatch/Views/
+| File | Purpose |
+|------|---------|
+| `SessionPlannerWindow.axaml` | Avalonia view with DataGrid, date/time pickers, export file dialogs |
+| `SessionPlannerWindow.axaml.cs` | Code-behind for file dialog interactions |
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `OscarWatch.Core/Models/AppSettings.cs` | Added `SatellitePriorities` dictionary and `SessionPlannerPreAlertMinutes` |
+| `OscarWatch.Core/Services/SettingsService.cs` | Null-coalescing for `SatellitePriorities` in `NormalizeSettings` |
+| `OscarWatch.Core/Properties/AssemblyInfo.cs` | Added `InternalsVisibleTo("OscarWatch")` |
+| `OscarWatch/App.axaml.cs` | DI registration for SessionPlannerService, PlanExecutor, SessionPlannerViewModel |
+| `OscarWatch/ViewModels/MainViewModel.cs` | Added `OpenSessionPlannerAsync` command |
+| `OscarWatch/MainWindow.axaml` | Added "Session Planner" menu item under Passes |
+| `OscarWatch/Resources/Strings.resx` | Added `Menu.Passes.SessionPlanner` localisation key |
+
+## Scoring algorithm
+
+```
+QualityScore = clamp(elevation/90) × 0.5
+             + clamp(duration/15) × 0.3
+             + transponderFactor × 0.2
+
+CompositeScore = QualityScore × (11 − SatellitePriority)
+```
+
+- Transponder factors: Linear=1.0, Mixed=0.8, Unknown=0.7, FM=0.6
+- Priority: 1 (highest) to 10 (lowest), default 5
+- Score range: 0.0 to 10.0
+
+## Scheduling algorithm
+
+Weighted interval scheduling via dynamic programming:
+1. Filter by minimum elevation threshold
+2. Sort candidates by LOS time
+3. Binary search for compatible predecessors (p[i])
+4. DP recurrence: `dp[i] = max(dp[i-1], dp[p[i]] + weight[i])`
+5. Backtrack to recover selected set
+6. Tie-break overlapping equal-score passes by higher elevation (epsilon)
+
+Handles forced inclusions by fixing them first, removing conflicts, then solving sub-problems in the gaps.
+
+## Plan execution
+
+- State machine: Idle → Running → Paused/Completed
+- Tick-driven (1s interval from ViewModel)
+- Focus switches at each pass's AOS (within 1 second)
+- Pre-alerts at `max(previousLOS, AOS − L minutes)` where L is configurable (default 3, range 1–15)
+- Manual override detection: pauses if operator changes focus externally
+- Retains focused satellite during gaps
+
+## Test coverage
+
+22 new tests (18 FsCheck property-based + 4 xUnit unit tests):
+
+| Test file | Properties |
+|-----------|-----------|
+| `SessionPlannerScoringPropertyTests.cs` | Score bounded [0,1]; composite formula |
+| `WeightedIntervalSchedulerPropertyTests.cs` | Non-overlap; optimality (brute-force ≤8 passes); elevation filtering; tie-breaking; AOS-sorted output |
+| `SessionPlanAdjustmentPropertyTests.cs` | Time accounting; exclusion respected; forced inclusion respected |
+| `PlanExecutorPropertyTests.cs` | Focus state correctness; pre-alert timing |
+| `SessionValidationPropertyTests.cs` | 15-minute rounding; invalid window rejection |
+| `SessionPlanPersistencePropertyTests.cs` | Serialisation round-trip |
+| `SessionPlanExportPropertyTests.cs` | ICS structure (VEVENT count, VALARM trigger); CSV completeness |
+| `SessionPlannerViewModelTests.cs` | Pause/resume transitions; plan completion; review-only mode |
+
+All 1358 tests pass (including the 22 new ones). Build succeeds with zero warnings.
+
+## Settings additions
+
+```json
+{
+  "satellitePriorities": { "ISS": 1, "SO-50": 3 },
+  "sessionPlannerPreAlertMinutes": 3
+}
+```
+
+## Export formats
+
+- **CSV**: Header + data rows (SatelliteName, NoradId, AOS_UTC, LOS_UTC, MaxElevationDeg, CompositeScore, Status)
+- **ICS**: VCALENDAR with one VEVENT per pass, each with VALARM trigger at configured lead time
+- **JSON**: Full plan persistence with version, session bounds, passes, scores, exclusions
+
+## Known limitations / future work
+
+- No satellite priority UI yet (values set via settings JSON only)
+- Voice announcements for pre-alerts are wired in the executor events but not connected to the UI speech service
+- No visual distinction for "tight gaps" (< 2 minutes) beyond the gap value being visible
+- The window doesn't have a live-updating timer during execution (needs DispatcherTimer wiring in the view)
+- Localization keys only added for English; other language resource files need the Session Planner strings


### PR DESCRIPTION
Implements an operating session planner that generates optimal non-overlapping satellite pass schedules using dynamic-programming weighted interval scheduling (O(n log n)).

Features:
- Define session time window with validation (max 48h)
- Score passes by elevation, duration, transponder type, and priority
- Optimal non-overlapping pass selection with tie-breaking
- Plan execution with automatic focus switching at AOS
- Pre-alert notifications (configurable 1-15 min lead time)
- Manual plan adjustment (exclude/force-include passes)
- Export to CSV and ICS (with VALARM)
- Save/load plans as JSON
- Accessible via Passes > Session Planner menu

Includes 22 new tests (18 FsCheck property-based + 4 xUnit unit) covering scoring, scheduling, execution, persistence, and export.