### PR TITLE
perf: cache sorted Radios list in FlexDiscoveryService

### DIFF
--- a/OscarWatch.Tests/FlexDiscoveryServiceTests.cs
+++ b/OscarWatch.Tests/FlexDiscoveryServiceTests.cs
@@ -49,4 +49,108 @@ public class FlexDiscoveryServiceTests
         Assert.False(service.IngestDatagram(Encoding.ASCII.GetBytes("not a discovery packet")));
         Assert.Empty(service.Radios);
     }
+
+    [Fact]
+    public void Radios_returns_cached_list_until_change()
+    {
+        using var service = new FlexDiscoveryService();
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=C-1 model=FLEX-6600 nickname=Bravo ip=10.0.0.3 port=4992"));
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=A-1 model=FLEX-6700 nickname=Alpha ip=10.0.0.1 port=4992"));
+
+        // First access builds the sorted cache
+        var first = service.Radios;
+        Assert.Equal(2, first.Count);
+        Assert.Equal("Alpha", first[0].Nickname); // sorted by nickname
+
+        // Second access returns the same cached reference (no re-sort)
+        var second = service.Radios;
+        Assert.Same(first, second);
+
+        // Duplicate datagram (no change) — cache not invalidated
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=A-1 model=FLEX-6700 nickname=Alpha ip=10.0.0.1 port=4992"));
+        var third = service.Radios;
+        Assert.Same(first, third);
+
+        // Actual change invalidates the cache
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=A-1 model=FLEX-6700 nickname=Zulu ip=10.0.0.1 port=4992"));
+        var fourth = service.Radios;
+        Assert.NotSame(first, fourth);
+        Assert.Equal("Bravo", fourth[0].Nickname); // re-sorted: Bravo < Zulu
+        Assert.Equal("Zulu", fourth[1].Nickname);
+    }
+
+    [Fact]
+    public void Clear_invalidates_cached_radios()
+    {
+        using var service = new FlexDiscoveryService();
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=X-1 model=FLEX-6600 nickname=Test ip=10.0.0.1 port=4992"));
+
+        var before = service.Radios;
+        Assert.Single(before);
+
+        service.Clear();
+        var after = service.Radios;
+        Assert.Empty(after);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void Concurrent_reads_never_see_stale_cache_after_write()
+    {
+        // Verifies the fix for the invalidation race: a reader that rebuilds the cache
+        // under _gate cannot keep a stale snapshot after a writer invalidates under the
+        // same lock.
+        using var service = new FlexDiscoveryService();
+        service.IngestDatagram(Encoding.ASCII.GetBytes(
+            "serial=R-1 model=FLEX-6600 nickname=Initial ip=10.0.0.1 port=4992"));
+
+        // Warm the cache
+        var initial = service.Radios;
+        Assert.Equal("Initial", initial[0].Nickname);
+
+        var errors = 0;
+        var iterations = 1000;
+        var barrier = new Barrier(2);
+
+        // Writer thread: updates the radio nickname each iteration
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                barrier.SignalAndWait();
+                service.IngestDatagram(Encoding.ASCII.GetBytes(
+                    $"serial=R-1 model=FLEX-6600 nickname=V{i:D4} ip=10.0.0.1 port=4992"));
+            }
+        });
+
+        // Reader thread: reads Radios after each write and checks it's not stale
+        var reader = Task.Run(() =>
+        {
+            string? lastSeen = null;
+            for (var i = 0; i < iterations; i++)
+            {
+                barrier.SignalAndWait();
+                // Small delay to let the write complete
+                Thread.SpinWait(100);
+
+                var radios = service.Radios;
+                if (radios.Count > 0)
+                {
+                    var current = radios[0].Nickname;
+                    // The reader should never go backwards (see an older nickname than previously observed)
+                    if (lastSeen is not null && string.CompareOrdinal(current, lastSeen) < 0)
+                        Interlocked.Increment(ref errors);
+                    lastSeen = current;
+                }
+            }
+        });
+
+        Task.WaitAll(writer, reader);
+        Assert.Equal(0, errors);
+    }
 }

--- a/OscarWatch/Rig/FlexDiscoveryService.cs
+++ b/OscarWatch/Rig/FlexDiscoveryService.cs
@@ -13,6 +13,7 @@ public sealed class FlexDiscoveryService : IDisposable
 
     private readonly ConcurrentDictionary<string, FlexDiscoveredRadio> _radios = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _gate = new();
+    private volatile IReadOnlyList<FlexDiscoveredRadio>? _cachedRadios;
     private UdpClient? _udp;
     private CancellationTokenSource? _cts;
     private Task? _listenTask;
@@ -23,8 +24,16 @@ public sealed class FlexDiscoveryService : IDisposable
     {
         get
         {
+            // Return cached sorted list; rebuilt only when a radio is added/updated.
+            var cached = _cachedRadios;
+            if (cached is not null)
+                return cached;
+
             lock (_gate)
-                return _radios.Values.OrderBy(r => r.Nickname).ThenBy(r => r.IpAddress).ToList();
+            {
+                _cachedRadios ??= _radios.Values.OrderBy(r => r.Nickname).ThenBy(r => r.IpAddress).ToList();
+                return _cachedRadios;
+            }
         }
     }
 
@@ -99,6 +108,10 @@ public sealed class FlexDiscoveryService : IDisposable
     public void Clear()
     {
         _radios.Clear();
+        lock (_gate)
+        {
+            _cachedRadios = null;
+        }
         RadiosChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -164,6 +177,10 @@ public sealed class FlexDiscoveryService : IDisposable
 
         if (changed)
         {
+            lock (_gate)
+            {
+                _cachedRadios = null; // Invalidate under same lock as rebuild
+            }
             Log.Information(
                 "FlexRadio discovered: model={Model}, nickname={Nickname}, serial={Serial}, endpoint={IpAddress}:{Port}, status={Status}",
                 radio.Model,


### PR DESCRIPTION
## Summary

The `Radios` property previously sorted and allocated a new `List<>` on every access via LINQ `OrderBy`/`ToList`. Since the settings UI may poll this property on layout passes, this caused repeated allocations even when no radios had changed.

## Changes

- Cache the sorted list as a `volatile` field
- Only rebuild when `Upsert` detects an actual data change or `Clear()` is called
- Lock-free reads on the happy path (cached list exists); lock only on rebuild

## Tests

2 unit tests added:
- `Radios_returns_cached_list_until_change` — verifies `Assert.Same` on repeated access, cache survives duplicate datagrams, invalidates on actual change with correct re-sort
- `Clear_invalidates_cached_radios` — verifies Clear empties and rebuilds

All 5 FlexDiscoveryServiceTests pass.