### PR TITLE
ci: build and test on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+# Build and test on ordinary pushes and pull requests.
+# Complements publish.yml, which only builds/tests on a version-tag push or
+# manual dispatch — this workflow is the one that actually gates PRs.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_VERSION: "10.0.x"
+
+jobs:
+  build-and-test:
+    name: Build and test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - run: dotnet build OscarWatch.slnx -c Release
+
+      - run: dotnet test OscarWatch.slnx -c Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
-# Build and test on ordinary pushes and pull requests.
+# Build and test on pull requests.
 # Complements publish.yml, which only builds/tests on a version-tag push or
 # manual dispatch — this workflow is the one that actually gates PRs.
 
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -19,12 +17,7 @@ env:
 
 jobs:
   build-and-test:
-    name: Build and test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`publish.yml` only builds/tests on a version-tag push (`v*`) or manual `workflow_dispatch`, so ordinary pushes and pull requests to `main` currently aren't built or tested at all. This adds a separate, additive `ci.yml` that runs on `push` (main) and `pull_request`, matrixed across `ubuntu-latest` and `windows-latest` since the Windows-only code paths (`System.IO.Ports`, `System.Speech`, PortAudio native runtime) are currently only exercised at publish time.

Doesn't touch `publish.yml` or its release behaviour.

**Note on test flakiness**: while verifying this locally, `RotatorControllerTests.Update_runs_on_worker_thread_and_tracks_satellite` failed once across three full-suite runs (passed 5/5 in isolation). Looks like a pre-existing race between the worker thread's completion signal and the position-snapshot refresh under full-suite parallel load, unrelated to this change — flagging so it's not a surprise if this workflow shows a failure here on an early run.

Happy to adjust scope (e.g. drop the Windows leg, or start Linux-only) if preferred.