### PR TITLE
perf: use dictionary index for community status satellite lookups

### DIFF
--- a/OscarWatch.Core/Services/SatelliteCommunityStatus.cs
+++ b/OscarWatch.Core/Services/SatelliteCommunityStatus.cs
@@ -33,21 +33,24 @@ public sealed record SatelliteCommunityCatalog(
     DateTime ServerTimeUtc,
     DateTime FetchedAtUtc)
 {
+    // O(1) lookup index built lazily on first access.
+    private Dictionary<string, SatelliteCommunitySatelliteStatus>? _index;
+
+    private Dictionary<string, SatelliteCommunitySatelliteStatus> Index =>
+        _index ??= Satellites.ToDictionary(s => s.Name, StringComparer.OrdinalIgnoreCase);
+
     public SatelliteCommunityModeStatus? TryGetMode(string satelliteName, string modeType)
     {
         if (string.IsNullOrWhiteSpace(satelliteName) || string.IsNullOrWhiteSpace(modeType))
             return null;
 
-        foreach (var sat in Satellites)
-        {
-            if (!string.Equals(sat.Name, satelliteName.Trim(), StringComparison.OrdinalIgnoreCase))
-                continue;
+        if (!Index.TryGetValue(satelliteName.Trim(), out var sat))
+            return null;
 
-            foreach (var mode in sat.Modes)
-            {
-                if (string.Equals(mode.ModeType, modeType.Trim(), StringComparison.OrdinalIgnoreCase))
-                    return mode;
-            }
+        foreach (var mode in sat.Modes)
+        {
+            if (string.Equals(mode.ModeType, modeType.Trim(), StringComparison.OrdinalIgnoreCase))
+                return mode;
         }
 
         return null;
@@ -58,13 +61,7 @@ public sealed record SatelliteCommunityCatalog(
         if (string.IsNullOrWhiteSpace(satelliteName))
             return null;
 
-        foreach (var sat in Satellites)
-        {
-            if (string.Equals(sat.Name, satelliteName.Trim(), StringComparison.OrdinalIgnoreCase))
-                return sat;
-        }
-
-        return null;
+        return Index.GetValueOrDefault(satelliteName.Trim());
     }
 }
 


### PR DESCRIPTION
## Summary

`TryGetMode` and `TryGetSatellite` on `SatelliteCommunityCatalog` previously iterated the `Satellites` list linearly on every call (O(n)). These are called from the UI rendering path for each enabled satellite's status indicator (~10 lookups per tick at 4 Hz = ~40 linear scans/second).

## Changes

Build a lazily-initialized `Dictionary<string, SatelliteCommunitySatelliteStatus>` keyed by satellite name (case-insensitive) on first access. Subsequent lookups are O(1). The index is built once per API fetch (every 5 minutes) and reused for all rendering ticks in between.

- `TryGetSatellite` → single `Dictionary.GetValueOrDefault` call
- `TryGetMode` → dictionary lookup for satellite, then short linear scan of modes (typically 1-3 modes per satellite)

## Tests

All 42 existing SatelliteStatus tests pass unchanged.