### PR TITLE
Fix Kenwood TH-D74/D75 CAT support

### DIFF
--- a/OscarWatch.Tests/KenwoodThD7xDriverTests.cs
+++ b/OscarWatch.Tests/KenwoodThD7xDriverTests.cs
@@ -6,17 +6,50 @@ namespace OscarWatch.Tests;
 public sealed class KenwoodThD7xDriverTests
 {
     [Fact]
-    public void SetMode_usb_sends_session_mode_and_fine_step()
+    public void Open_establishes_session_and_reads_band_b_frequency()
     {
-        var transport = new RecordingKenwoodHtTransport();
+        var transport = new RecordingKenwoodHtTransport
+        {
+            FrequencyResponse = "FO 1,0435750000,0,0,0,0"
+        };
         var driver = new KenwoodThD7xDriver(RigType.KenwoodThD75, transport, catDelayMs: 0);
+
         driver.Open();
-        driver.SetMode("USB");
 
         Assert.Equal(
         [
             "VM 1,0\r",
             "BC 1\r",
+            "FO 1\r"
+        ],
+        transport.SentCommands);
+        Assert.Equal(435_750_000, driver.ReadFrequencyHz(RigVfo.Main));
+    }
+
+    [Fact]
+    public void Open_throws_when_fo_response_is_missing()
+    {
+        var transport = new RecordingKenwoodHtTransport
+        {
+            FrequencyResponse = null
+        };
+        var driver = new KenwoodThD7xDriver(RigType.KenwoodThD74, transport, catDelayMs: 0);
+
+        var ex = Assert.Throws<InvalidOperationException>(driver.Open);
+        Assert.Contains("FO 1", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SetMode_usb_sends_session_mode_and_fine_step()
+    {
+        var transport = new RecordingKenwoodHtTransport();
+        var driver = new KenwoodThD7xDriver(RigType.KenwoodThD75, transport, catDelayMs: 0);
+        driver.Open();
+        transport.SentCommands.Clear();
+        driver.SetMode("USB");
+
+        Assert.Equal(
+        [
             "MD 1,4\r",
             "FT 1\r",
             "FS 0\r"
@@ -66,8 +99,9 @@ public sealed class KenwoodThD7xDriverTests
         };
         var driver = new KenwoodThD7xDriver(RigType.KenwoodThD75, transport, catDelayMs: 0);
         driver.Open();
+        transport.SentCommands.Clear();
 
         Assert.Equal(435_750_000, driver.ReadFrequencyHz(RigVfo.Main));
-        Assert.Contains("FO 1\r", transport.SentCommands);
+        Assert.Equal(["FO 1\r"], transport.SentCommands);
     }
 }

--- a/OscarWatch/Rig/KenwoodHtTransport.cs
+++ b/OscarWatch/Rig/KenwoodHtTransport.cs
@@ -16,10 +16,12 @@ internal sealed class KenwoodHtTransport : IKenwoodHtTransport
         _port = new SerialPort(portName, baudRate, Parity.None, 8, StopBits.One)
         {
             Handshake = Handshake.None,
-            ReadTimeout = 250,
-            WriteTimeout = 1000,
-            DtrEnable = false,
-            RtsEnable = false,
+            // The TH-D74/D75 USB CDC interface needs the modem-control lines
+            // asserted on macOS. This also matches the CardSat TH-D75 probe.
+            ReadTimeout = 400,
+            WriteTimeout = 2000,
+            DtrEnable = true,
+            RtsEnable = true,
             NewLine = "\r"
         };
     }
@@ -28,8 +30,18 @@ internal sealed class KenwoodHtTransport : IKenwoodHtTransport
 
     public void Open()
     {
-        if (!_port.IsOpen)
-            _port.Open();
+        if (_port.IsOpen)
+            return;
+
+        _port.Open();
+
+        // System.IO.Ports can open the macOS /dev/cu.* node before the radio's
+        // USB CDC command channel is ready. Reassert the lines after Open() and
+        // allow the TH-D7x time to settle before the first CAT transaction.
+        _port.DtrEnable = true;
+        _port.RtsEnable = true;
+        Thread.Sleep(200);
+        DrainInput();
     }
 
     public bool SendCommand(string command, int postDelayMs = 50)
@@ -71,7 +83,7 @@ internal sealed class KenwoodHtTransport : IKenwoodHtTransport
                 return null;
             DrainInput();
             _port.Write(Normalize(command));
-            return ReadUntilCr(Math.Max(220, postDelayMs + 170));
+            return ReadUntilCr(Math.Max(500, postDelayMs + 400));
         }
         catch (Exception ex)
         {
@@ -86,7 +98,30 @@ internal sealed class KenwoodHtTransport : IKenwoodHtTransport
 
     public void Dispose()
     {
-        try { if (_port.IsOpen) _port.Close(); } catch { }
+        try
+        {
+            if (_port.IsOpen)
+            {
+                // Drop the CDC control lines explicitly so a subsequent open
+                // starts a clean TH-D7x PC-command session on macOS.
+                try
+                {
+                    _port.DtrEnable = false;
+                    _port.RtsEnable = false;
+                }
+                catch
+                {
+                    // Best effort; closing the port is still required.
+                }
+
+                _port.Close();
+            }
+        }
+        catch
+        {
+            // Best effort during shutdown.
+        }
+
         _port.Dispose();
         _gate.Dispose();
     }

--- a/OscarWatch/Rig/KenwoodThD7xDriver.cs
+++ b/OscarWatch/Rig/KenwoodThD7xDriver.cs
@@ -44,6 +44,25 @@ public sealed class KenwoodThD7xDriver : IRigDriver
         _transport.Open();
         _sessionReady = false;
         _lastFrequencyBand = -1;
+
+        // Do not report a successful connection merely because macOS allowed
+        // the /dev/cu.* device to be opened. Put Band B into the expected CAT
+        // state and require a valid FO response from the radio. The larger
+        // startup delay gives USB CDC devices a full transaction budget.
+        if (!EnsureSession())
+            throw new InvalidOperationException($"{_rigType} opened, but CAT session setup failed.");
+
+        var response = _transport.Transact(
+            KenwoodThD7xCatCodec.BuildReadFrequencyCommand(),
+            Math.Max(600, _catDelayMs));
+
+        if (response is null || !KenwoodThD7xCatCodec.TryParseFrequencyHz(response, out var hz))
+            throw new InvalidOperationException(
+                $"{_rigType} serial port opened, but the radio did not return a valid FO 1 response. " +
+                "On macOS select the /dev/cu.* device for the radio and verify PC command mode is enabled.");
+
+        _lastFrequencyHz = hz;
+        Log.Information("Connected to {RigType}; initial Band B frequency {FrequencyHz} Hz", _rigType, hz);
     }
 
     public long? ReadFrequencyHz(RigVfo vfo)

--- a/documents/building-radio-drivers.md
+++ b/documents/building-radio-drivers.md
@@ -321,12 +321,12 @@ Covers **FTX-1 Field** and **FTX-1optima** (same field head). Downlink uses VFO-
 | Piece | Path |
 |-------|------|
 | CAT codec | [`OscarWatch.Core/Radio/KenwoodThD7xCatCodec.cs`](../OscarWatch.Core/Radio/KenwoodThD7xCatCodec.cs) |
-| Serial transport | [`OscarWatch/Rig/KenwoodHtTransport.cs`](../OscarWatch/Rig/KenwoodHtTransport.cs) — **8N1**, CR-terminated ASCII, no RTS/CTS |
+| Serial transport | [`OscarWatch/Rig/KenwoodHtTransport.cs`](../OscarWatch/Rig/KenwoodHtTransport.cs) — **8N1**, CR-terminated ASCII, no RTS/CTS handshake; DTR/RTS modem lines asserted for USB CDC |
 | Driver | [`OscarWatch/Rig/KenwoodThD7xDriver.cs`](../OscarWatch/Rig/KenwoodThD7xDriver.cs) |
 
 - **Dual radio only** (`RigSettings.DualRadioEnabled`): TH-D74/TH-D75 are not offered in the single-radio driver list. Each endpoint is one physical HT on **Band B** (all-mode receiver).
 - Different dialect from the TS-2000: CR framing, `FQ`/`FO`/`MD`/`VM`/`BC`/`FT`/`FS` (not semicolon `FA`/`FB` SATL).
-- Session once after open: `VM 1,0` then `BC 1`. FM/data-FM uses NFM (`MD` code 6) on a **5 kHz** grid; USB/LSB/CW/AM use fine tune + **20 Hz** step. Cross-band `FQ` re-applies `FT`/`FS` because the HT stores step per band.
+- On open: assert DTR/RTS, settle briefly, then `VM 1,0`, `BC 1`, and a verified `FO 1` read before reporting connected. FM/data-FM uses NFM (`MD` code 6) on a **5 kHz** grid; USB/LSB/CW/AM use fine tune + **20 Hz** step. Cross-band `FQ` re-applies `FT`/`FS` because the HT stores step per band.
 - `SupportsVfoExchange` is **false**. CTCSS CAT is intentionally a no-op until hardware-validated; set uplink tone on the radio manually for FM satellites.
 - Protocol behaviour follows CardSat’s bench-tested TH-D7x subset (`LEGF_KWHT`).
 
@@ -334,6 +334,7 @@ Covers **FTX-1 Field** and **FTX-1optima** (same field head). Downlink uses VFO-
 
 - Enable **Settings → Radio → Dual radio**; choose TH-D74 or TH-D75 on each leg with the USB/PC COM port at **9600** 8N1 (user-selectable).
 - Use normal PC-command mode (not KISS/TNC). Disable unsolicited GPS PC output if enabled.
+- On macOS select the radio’s `/dev/cu.*` device (not `/dev/tty.*`); OscarWatch treats a silent FO reply as a failed connection.
 - On a real pass: Doppler on Band B; for FM uplinks needing CTCSS, set the tone on the HT yourself for now.
 
 ## Reference: FlexRadio SmartSDR (shipped)


### PR DESCRIPTION
## Summary

This fixes Kenwood TH-D74/TH-D75 CAT communication when using the radios through their USB CDC serial interface.

The existing TH-D7x implementation could successfully open the macOS `/dev/cu.usbmodem*` device without establishing actual CAT communication with the radio. This could result in OscarWatch reporting the endpoint as connected even though the radio was not responding.

This change has been successfully tested on Apple Silicon macOS.

## Changes

- Assert DTR and RTS when opening the TH-D74/D75 USB CDC serial connection.
- Add a 200 ms settling delay before beginning CAT communication.
- Increase serial/CAT response timeouts for reliable USB CDC operation.
- Verify actual communication with the radio using an `FO 1` frequency query during connection.
- Explicitly lower DTR and RTS when closing the serial connection.

## Result

OscarWatch now distinguishes between successfully opening a macOS serial device and actually communicating with a TH-D74/D75.

The resulting connection sequence is:

```text
Open serial port
       |
       v
DTR ON / RTS ON
       |
       v
Wait 200 ms
       |
       v
VM 1,0
       |
       v
BC 1
       |
       v
FO 1
       |
       v
Validate frequency response
       |
       v
Connection ready
```

## Scope

These changes are limited to the Kenwood TH-D74/TH-D75 driver and transport. Other OscarWatch rig drivers are unchanged.

## Testing

Tested successfully on:

- Apple Silicon Mac
- macOS
- Kenwood TH-D75 USB CDC serial connection
- 9600 baud
- `/dev/cu.usbmodem*`

The test confirmed that OscarWatch establishes CAT communication with the radio and controls it rather than merely opening the serial device.