### PR TITLE
Performance: Optimize FlexSmartSdrCodec.ParseKeyValues with Span<T>

### DIFF
--- a/OscarWatch.Core/Radio/FlexSmartSdrCodec.cs
+++ b/OscarWatch.Core/Radio/FlexSmartSdrCodec.cs
@@ -415,7 +415,8 @@ public static class FlexSmartSdrCodec
     {
         var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         
-        // Optimized: Use ReadOnlySpan<char> to avoid string allocations during parsing
+        // Optimized: Use ReadOnlySpan<char> to avoid Split() array allocations during parsing
+        // Note: Still allocates strings for keys/values via ToString(); the win is avoiding Split() array/token allocations
         var span = text.AsSpan();
         var pos = 0;
         

--- a/OscarWatch.Core/Radio/FlexSmartSdrCodec.cs
+++ b/OscarWatch.Core/Radio/FlexSmartSdrCodec.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace OscarWatch.Core.Radio;
@@ -413,17 +414,44 @@ public static class FlexSmartSdrCodec
     private static Dictionary<string, string> ParseKeyValues(string text)
     {
         var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var token in text.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        
+        // Optimized: Use ReadOnlySpan<char> to avoid string allocations during parsing
+        var span = text.AsSpan();
+        var pos = 0;
+        
+        while (pos < span.Length)
         {
-            var eq = token.IndexOf('=');
-            if (eq <= 0 || eq >= token.Length - 1)
+            // Skip whitespace
+            while (pos < span.Length && IsWhitespace(span[pos]))
+                pos++;
+                
+            if (pos >= span.Length)
+                break;
+                
+            // Find end of token (next whitespace or end)
+            var tokenStart = pos;
+            while (pos < span.Length && !IsWhitespace(span[pos]))
+                pos++;
+                
+            var token = span.Slice(tokenStart, pos - tokenStart);
+            
+            // Find equals sign in token
+            var eqIndex = token.IndexOf('=');
+            if (eqIndex <= 0 || eqIndex >= token.Length - 1)
                 continue;
-
-            fields[token[..eq]] = token[(eq + 1)..];
+                
+            // Extract key and value using spans, then convert to strings only when storing
+            var keySpan = token.Slice(0, eqIndex);
+            var valueSpan = token.Slice(eqIndex + 1);
+            
+            fields[keySpan.ToString()] = valueSpan.ToString();
         }
-
+        
         return fields;
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsWhitespace(char c) => c == ' ' || c == '\t' || c == '\r' || c == '\n';
 
     private static int GetInt(Dictionary<string, string> fields, string key, int fallback)
     {

--- a/OscarWatch.Tests/FlexSmartSdrCodecParseKeyValuesOptimizationTests.cs
+++ b/OscarWatch.Tests/FlexSmartSdrCodecParseKeyValuesOptimizationTests.cs
@@ -1,0 +1,200 @@
+using OscarWatch.Core.Radio;
+using System.Reflection;
+
+namespace OscarWatch.Tests;
+
+/// <summary>
+/// Tests for the FlexSmartSdrCodec.ParseKeyValues Span optimization.
+/// Verifies functional equivalence and performance improvement.
+/// </summary>
+public class FlexSmartSdrCodecParseKeyValuesOptimizationTests
+{
+    [Fact]
+    public void ParseKeyValues_handles_simple_key_value_pairs()
+    {
+        // Arrange
+        var input = "freq=14.230 mode=USB active=1";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("14.230", result["freq"]);
+        Assert.Equal("USB", result["mode"]);  
+        Assert.Equal("1", result["active"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_mixed_whitespace_delimiters()
+    {
+        // Arrange
+        var input = "freq=14.230\tmode=USB\r\nactive=1 tx=0";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(4, result.Count);
+        Assert.Equal("14.230", result["freq"]);
+        Assert.Equal("USB", result["mode"]);
+        Assert.Equal("1", result["active"]);
+        Assert.Equal("0", result["tx"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_ignores_malformed_tokens()
+    {
+        // Arrange - Mix valid and invalid tokens
+        var input = "freq=14.230 invalid mode=USB =badkey goodkey= active=1";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert - Should only include valid key=value pairs
+        Assert.Equal(3, result.Count);
+        Assert.Equal("14.230", result["freq"]);
+        Assert.Equal("USB", result["mode"]);
+        Assert.Equal("1", result["active"]);
+        Assert.False(result.ContainsKey("invalid"));
+        Assert.False(result.ContainsKey("badkey"));
+        Assert.False(result.ContainsKey("goodkey"));
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_case_insensitive_keys()
+    {
+        // Arrange
+        var input = "FREQ=14.230 Mode=USB active=1";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("14.230", result["freq"]); // Should be case insensitive
+        Assert.Equal("USB", result["MODE"]);    // Should be case insensitive  
+        Assert.Equal("1", result["ACTIVE"]);    // Should be case insensitive
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_empty_and_whitespace_only_input()
+    {
+        // Arrange & Act & Assert
+        Assert.Empty(CallParseKeyValues(""));
+        Assert.Empty(CallParseKeyValues(" "));
+        Assert.Empty(CallParseKeyValues("\t\r\n"));
+        Assert.Empty(CallParseKeyValues("   \t  \r\n  "));
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_values_with_special_characters()
+    {
+        // Arrange
+        var input = "pan=0x40000000 mode=AM txant=ANT1 call=W1AW/B";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(4, result.Count);
+        Assert.Equal("0x40000000", result["pan"]);
+        Assert.Equal("AM", result["mode"]);
+        Assert.Equal("ANT1", result["txant"]);
+        Assert.Equal("W1AW/B", result["call"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_numeric_values()
+    {
+        // Arrange
+        var input = "freq=14.230123 active=1 tx=0 rf_power=50.5";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(4, result.Count);
+        Assert.Equal("14.230123", result["freq"]);
+        Assert.Equal("1", result["active"]);
+        Assert.Equal("0", result["tx"]);
+        Assert.Equal("50.5", result["rf_power"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_realistic_flex_status_message()
+    {
+        // Arrange - Based on actual Flex radio status messages
+        var input = "in_use=1 RF_frequency=14.230 mode=USB active=1 tx=0 wide=0 " +
+                   "pan=0x40000000 txant=ANT1 rxant=ANT1 fm_tone_mode=off";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert - There are 10 key-value pairs in the input string
+        Assert.Equal(10, result.Count);
+        Assert.Equal("1", result["in_use"]);
+        Assert.Equal("14.230", result["RF_frequency"]);
+        Assert.Equal("USB", result["mode"]);
+        Assert.Equal("1", result["active"]);
+        Assert.Equal("0", result["tx"]);
+        Assert.Equal("0", result["wide"]);
+        Assert.Equal("0x40000000", result["pan"]);
+        Assert.Equal("ANT1", result["txant"]);
+        Assert.Equal("ANT1", result["rxant"]);
+        Assert.Equal("off", result["fm_tone_mode"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_leading_and_trailing_whitespace()
+    {
+        // Arrange
+        var input = "  freq=14.230   mode=USB   active=1  ";
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("14.230", result["freq"]);
+        Assert.Equal("USB", result["mode"]);
+        Assert.Equal("1", result["active"]);
+    }
+
+    [Fact]
+    public void ParseKeyValues_handles_large_input_efficiently()
+    {
+        // Arrange - Create a larger input to test allocation efficiency
+        var tokens = new List<string>();
+        for (int i = 0; i < 100; i++)
+        {
+            tokens.Add($"key{i}=value{i}");
+        }
+        var input = string.Join(" ", tokens);
+
+        // Act
+        var result = CallParseKeyValues(input);
+
+        // Assert
+        Assert.Equal(100, result.Count);
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.Equal($"value{i}", result[$"key{i}"]);
+        }
+    }
+
+    /// <summary>
+    /// Uses reflection to call the private ParseKeyValues method.
+    /// This ensures we're testing the actual optimized implementation.
+    /// </summary>
+    private static Dictionary<string, string> CallParseKeyValues(string input)
+    {
+        var type = typeof(FlexSmartSdrCodec);
+        var method = type.GetMethod("ParseKeyValues", BindingFlags.NonPublic | BindingFlags.Static);
+        
+        Assert.NotNull(method);
+        
+        var result = method.Invoke(null, [input]);
+        return (Dictionary<string, string>)result!;
+    }
+}

--- a/OscarWatch.Tests/FlexSmartSdrCodecParseKeyValuesOptimizationTests.cs
+++ b/OscarWatch.Tests/FlexSmartSdrCodecParseKeyValuesOptimizationTests.cs
@@ -5,7 +5,7 @@ namespace OscarWatch.Tests;
 
 /// <summary>
 /// Tests for the FlexSmartSdrCodec.ParseKeyValues Span optimization.
-/// Verifies functional equivalence and performance improvement.
+/// Verifies functional equivalence and behavioral correctness.
 /// </summary>
 public class FlexSmartSdrCodecParseKeyValuesOptimizationTests
 {
@@ -195,6 +195,6 @@ public class FlexSmartSdrCodecParseKeyValuesOptimizationTests
         Assert.NotNull(method);
         
         var result = method.Invoke(null, [input]);
-        return (Dictionary<string, string>)result!;
+        return Assert.IsType<Dictionary<string, string>>(result);
     }
 }


### PR DESCRIPTION
## Summary
Optimizes FlexSmartSdrCodec.ParseKeyValues using Span<T> to eliminate Split() array allocations during radio communication parsing.

## Changes
• Replaced string.Split() with manual ReadOnlySpan<char> parsing
• Eliminated intermediate array allocations during tokenization process  
• Added aggressive inlining for whitespace detection helper method
• Maintained case-insensitive dictionary behavior and all existing functionality

## Performance Impact
• Eliminates array allocations from Split() operations
• Reduces allocation pressure in radio communication hot paths
• Particularly beneficial for high-frequency Flex radio status updates
• Note: Still allocates strings for keys/values via ToString(); the win is avoiding Split() array/token allocations

## Technical Details
• Manual tokenization using ReadOnlySpan<char>.Slice() operations
• Char-by-char parsing to identify tokens and equals signs
• [MethodImpl(MethodImplOptions.AggressiveInlining)] for hot path methods
• Only convert spans to strings when storing final key-value pairs

## Radio Communication Context
• ParseKeyValues processes Flex radio status messages containing 5-10 key-value pairs
• Called continuously during active radio communication sessions
• Typical input: "in_use=1 RF_frequency=14.230 mode=USB active=1 tx=0 pan=0x40000000"
• High-frequency parsing makes allocation reduction significant

## Testing
• Added comprehensive test suite: FlexSmartSdrCodecParseKeyValuesOptimizationTests
• 10 test scenarios: simple pairs, mixed whitespace, malformed tokens, case sensitivity, large inputs, realistic Flex messages
• Uses reflection to test private method directly ensuring implementation accuracy
• Verified functional equivalence with original string-based implementation

## Code Review Notes
• The optimization maintains identical case-insensitive behavior via StringComparer.OrdinalIgnoreCase
• Span-based parsing handles all whitespace characters (space, tab, CR, LF)
• Error handling for malformed tokens (missing/invalid equals signs) preserved
• Addresses Peter's feedback: test summary, Assert.IsType usage, span comment clarification

## Changes from previous PR #106
• Clean focused branch with only ParseKeyValues optimization (2 files changed)
• Rebased on current main
• Addressed all Peter's feedback items
