### PR TITLE
Shorten Publish workflow artifact retention to 7 days

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,7 @@ jobs:
           name: OscarWatch-${{ matrix.rid }}
           path: ${{ steps.archive.outputs.path }}
           if-no-files-found: error
+          retention-days: 7
 
   release:
     name: GitHub Release


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publish uploads six self-contained RID archives per run via `actions/upload-artifact@v4` with no `retention-days`, so GitHub keeps them for the default 90 days. About 30 live Publish batches currently sit at roughly 9.75 GiB in Actions storage. Tag releases already attach the same files via `softprops/action-gh-release`, so long-lived Actions artifacts are not needed.

This change sets `retention-days: 7` on the upload step in `publish.yml`.

## Workflow audit

| Workflow | Artifact upload | Change |
|----------|-----------------|--------|
| `.github/workflows/publish.yml` | `actions/upload-artifact@v4` (6 matrix RIDs) | Added `retention-days: 7` |
| `.github/workflows/ci.yml` | None | Unchanged |
| `.github/workflows/build-ft4-native.yml` | Not present in this repository | N/A |

## What is unchanged

- Build, test, publish, archive, and release steps
- `softprops/action-gh-release` behaviour
- Application code

## Storage impact

New Publish runs will expire artifacts after 7 days instead of 90. Existing artifacts are not retroactively shortened; they can be deleted manually in the Actions UI if you want immediate quota relief.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f8e274e-8271-4654-af72-ecda42772fa4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8e274e-8271-4654-af72-ecda42772fa4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

