### PR TITLE
Fix Flex pan recovery skipping collapsed dual-band pans

### DIFF
--- a/OscarWatch/Rig/FlexSmartSdrClient.cs
+++ b/OscarWatch/Rig/FlexSmartSdrClient.cs
@@ -2144,11 +2144,17 @@ internal sealed class FlexSmartSdrClient : IDisposable
         var response = SendAndWaitResponseUnlocked(FlexSmartSdrCodec.BuildSubPanAllCommand);
         if (response is null || !FlexSmartSdrCodec.IsSuccessResponse(response))
         {
-            Log.Warning(
-                "FlexRadio pan status refresh failed; dual-band layout may be stale: detail={Detail}",
-                response is null
-                    ? "(timeout)"
-                    : $"hex=0x{response.HexResponse:X8}, body={TruncateForLog(response.Body)}");
+            if (response is null)
+            {
+                Log.Warning(
+                    "FlexRadio pan status refresh failed; dual-band layout may be stale: detail=(timeout)");
+            }
+            else
+            {
+                Log.Warning(
+                    "FlexRadio pan status refresh failed; dual-band layout may be stale: hex=0x{Hex:X8}",
+                    response.HexResponse);
+            }
         }
 
         DrainPendingStatusUnlocked();

--- a/OscarWatch/Rig/FlexSmartSdrClient.cs
+++ b/OscarWatch/Rig/FlexSmartSdrClient.cs
@@ -2135,11 +2135,23 @@ internal sealed class FlexSmartSdrClient : IDisposable
     /// the dual-band layout. A non-blocking drain can miss a just-emitted collapse (loopback
     /// <see cref="NetworkStream.DataAvailable"/> race), which made Ensure/Verify treat two UHF
     /// pans as still healthy and skip recovery (GitHub issue 111).
+    /// Drains again after the subscribe ACK so a post-response pan dump is applied before callers
+    /// inspect <c>_pans</c>.
     /// </summary>
     private void RefreshLivePanStatusUnlocked()
     {
         DrainPendingStatusUnlocked();
-        _ = SendAndWaitResponseUnlocked(FlexSmartSdrCodec.BuildSubPanAllCommand);
+        var response = SendAndWaitResponseUnlocked(FlexSmartSdrCodec.BuildSubPanAllCommand);
+        if (response is null || !FlexSmartSdrCodec.IsSuccessResponse(response))
+        {
+            Log.Warning(
+                "FlexRadio pan status refresh failed; dual-band layout may be stale: detail={Detail}",
+                response is null
+                    ? "(timeout)"
+                    : $"hex=0x{response.HexResponse:X8}, body={TruncateForLog(response.Body)}");
+        }
+
+        DrainPendingStatusUnlocked();
     }
 
     private void DrainPendingStatusUnlocked()

--- a/OscarWatch/Rig/FlexSmartSdrClient.cs
+++ b/OscarWatch/Rig/FlexSmartSdrClient.cs
@@ -1814,7 +1814,9 @@ internal sealed class FlexSmartSdrClient : IDisposable
     {
         if (string.IsNullOrEmpty(body))
             return "";
-        return body.Length <= 120 ? body : body[..120] + "…";
+
+        var sanitized = body.Replace('\r', ' ').Replace('\n', ' ');
+        return sanitized.Length <= 120 ? sanitized : sanitized[..120] + "…";
     }
 
     public bool SetSliceTone(int sliceIndex, bool toneOn, double toneHz)
@@ -2152,8 +2154,9 @@ internal sealed class FlexSmartSdrClient : IDisposable
             else
             {
                 Log.Warning(
-                    "FlexRadio pan status refresh failed; dual-band layout may be stale: hex=0x{Hex:X8}",
-                    response.HexResponse);
+                    "FlexRadio pan status refresh failed; dual-band layout may be stale: hex=0x{Hex:X8}, body={Body}",
+                    response.HexResponse,
+                    TruncateForLog(response.Body));
             }
         }
 

--- a/OscarWatch/Rig/FlexSmartSdrClient.cs
+++ b/OscarWatch/Rig/FlexSmartSdrClient.cs
@@ -339,7 +339,7 @@ internal sealed class FlexSmartSdrClient : IDisposable
         lock (_gate)
         {
             EnsureConnectedUnlocked();
-            DrainPendingStatusUnlocked();
+            RefreshLivePanStatusUnlocked();
             InvalidateStaleBandPanLocksUnlocked();
 
             if (!FlexPanBandResolver.TryResolveBandPans(_pans.Values, out var vhfPan, out var uhfPan)
@@ -378,7 +378,7 @@ internal sealed class FlexSmartSdrClient : IDisposable
         lock (_gate)
         {
             EnsureConnectedUnlocked();
-            DrainPendingStatusUnlocked();
+            RefreshLivePanStatusUnlocked();
             InvalidateStaleBandPanLocksUnlocked();
 
             if (TryLockLiveDualBandPansUnlocked())
@@ -483,7 +483,7 @@ internal sealed class FlexSmartSdrClient : IDisposable
         lock (_gate)
         {
             EnsureConnectedUnlocked();
-            DrainPendingStatusUnlocked();
+            RefreshLivePanStatusUnlocked();
             InvalidateStaleBandPanLocksUnlocked();
             EnsureLockedBandPansUnlocked();
 
@@ -917,7 +917,7 @@ internal sealed class FlexSmartSdrClient : IDisposable
         lock (_gate)
         {
             EnsureConnectedUnlocked();
-            DrainPendingStatusUnlocked();
+            RefreshLivePanStatusUnlocked();
             InvalidateStaleBandPanLocksUnlocked();
             if (!TryLockLiveDualBandPansUnlocked())
                 EnsureLockedBandPansUnlocked();
@@ -2128,6 +2128,18 @@ internal sealed class FlexSmartSdrClient : IDisposable
         else
             _slices[sliceIndex] = new FlexSliceState(
                 sliceIndex, true, hz, "", false, false, "", 0);
+    }
+
+    /// <summary>
+    /// Re-subscribes to pan status so unsolicited centre changes are applied before we trust
+    /// the dual-band layout. A non-blocking drain can miss a just-emitted collapse (loopback
+    /// <see cref="NetworkStream.DataAvailable"/> race), which made Ensure/Verify treat two UHF
+    /// pans as still healthy and skip recovery (GitHub issue 111).
+    /// </summary>
+    private void RefreshLivePanStatusUnlocked()
+    {
+        DrainPendingStatusUnlocked();
+        _ = SendAndWaitResponseUnlocked(FlexSmartSdrCodec.BuildSubPanAllCommand);
     }
 
     private void DrainPendingStatusUnlocked()


### PR DESCRIPTION
﻿## Summary
- Fixes #111: dual-band pan recovery was skipped when both pans had collapsed onto UHF.
- `EnsureDualBandPanLayout`, `VerifyDuplexSliceFrequencies`, `CenterBandPans`, and `TryRelockBandPansFromLiveCentres` now re-subscribe with `sub pan all` before trusting live VHF/UHF layout.
- A non-blocking drain could miss just-emitted collapse status, so the client still thought the pans were healthy and never sent recovery commands.

## Test plan
- [ ] `EnsureDualBandPanLayout_recovers_when_both_pans_collapsed_onto_uhf`
- [ ] `EnsureDualBandPanLayout_then_bind_places_slices_on_separate_band_pans`
- [ ] `EnsureDuplexPassFrequencies_recovers_collapsed_pans_instead_of_preserving_bad_locks`
- [ ] Full `FlexRadioDriverTests` suite
